### PR TITLE
fix(skills): dedup 3 capas en persistencia y sync

### DIFF
--- a/database/match_ofertas_v3.py
+++ b/database/match_ofertas_v3.py
@@ -1422,8 +1422,29 @@ class MatcherV3:
                 (str(id_oferta),)
             )
 
-            count = 0
+            # Dedup: filtrar skills sin URI + deduplicar por URI (mayor score gana)
+            seen_uris = {}
+            skipped_no_uri = 0
             for skill in skills:
+                uri = (skill.get('skill_uri') or '').strip()
+                if not uri:
+                    skipped_no_uri += 1
+                    continue
+                if uri in seen_uris:
+                    if (skill.get('score') or 0) > (seen_uris[uri].get('score') or 0):
+                        seen_uris[uri] = skill
+                else:
+                    seen_uris[uri] = skill
+
+            if skipped_no_uri and self.verbose:
+                print(f"[V3] {skipped_no_uri} skills sin URI filtradas para {id_oferta}")
+
+            deduped = len(skills) - skipped_no_uri - len(seen_uris)
+            if deduped > 0 and self.verbose:
+                print(f"[V3] {deduped} skills duplicadas por URI eliminadas para {id_oferta}")
+
+            count = 0
+            for skill in seen_uris.values():
                 self.conn.execute('''
                     INSERT INTO ofertas_esco_skills_detalle (
                         id_oferta, skill_mencionado, skill_tipo_fuente,
@@ -1434,11 +1455,11 @@ class MatcherV3:
                     str(id_oferta),
                     skill.get('skill_esco', skill.get('skill', '')),
                     skill.get('origen', 'unknown'),
-                    skill.get('skill_uri', ''),  # URI de la skill ESCO
+                    skill.get('skill_uri', ''),
                     skill.get('skill_esco', ''),
                     skill.get('score', 0),
                     'implicit_bge_m3',
-                    skill.get('L1', 'T'),  # Categoría L1
+                    skill.get('L1', 'T'),
                     json.dumps({
                         'L1': skill.get('L1', ''),
                         'L1_nombre': skill.get('L1_nombre', ''),

--- a/scripts/exports/sync_to_supabase.py
+++ b/scripts/exports/sync_to_supabase.py
@@ -31,6 +31,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Dict, Any
+import unicodedata
 from unicodedata import normalize as unicode_normalize
 
 # Setup paths
@@ -784,19 +785,47 @@ def upsert_skills(client, skills: List[Dict], dry_run: bool = False) -> int:
     # Filtrar skills sin URI (inválidos)
     skills_transformed = [s for s in skills_transformed if s.get('skill_uri')]
 
-    # Deduplicar por (id_oferta, skill_uri) - quedarse con el primero
-    seen = set()
-    skills_unique = []
+    # Deduplicar por (id_oferta, skill_uri) - quedarse con mayor score
+    seen = {}
     for s in skills_transformed:
         key = (s['id_oferta'], s['skill_uri'])
-        if key not in seen:
-            seen.add(key)
-            skills_unique.append(s)
+        if key not in seen or (s.get('score') or 0) > (seen[key].get('score') or 0):
+            seen[key] = s
+    skills_unique = list(seen.values())
 
     if len(skills_unique) < len(skills_transformed):
-        logger.warning(f"Se eliminaron {len(skills_transformed) - len(skills_unique)} skills duplicados")
+        logger.warning(f"Se eliminaron {len(skills_transformed) - len(skills_unique)} skills duplicados por URI")
 
-    skills_transformed = skills_unique
+    # Segunda pasada: dedup semántica por label normalizado (sin acentos)
+    # Atrapa variantes como "negocio electronico" vs "negocio electrónico"
+    def _normalize_label(label):
+        if not label:
+            return ''
+        nfkd = unicodedata.normalize('NFKD', label)
+        return ''.join(c for c in nfkd if not unicodedata.combining(c)).lower().strip()
+
+    seen_labels = {}
+    skills_final = []
+    for s in skills_unique:
+        label_key = (s['id_oferta'], _normalize_label(s.get('preferred_label', '')))
+        if label_key[1] == '':
+            # Sin label, no se puede deduplicar semánticamente
+            skills_final.append(s)
+            continue
+        if label_key not in seen_labels:
+            seen_labels[label_key] = s
+            skills_final.append(s)
+        else:
+            existing = seen_labels[label_key]
+            if (s.get('score') or 0) > (existing.get('score') or 0):
+                skills_final.remove(existing)
+                seen_labels[label_key] = s
+                skills_final.append(s)
+
+    if len(skills_final) < len(skills_unique):
+        logger.warning(f"Se eliminaron {len(skills_unique) - len(skills_final)} skills duplicados semánticos (label normalizado)")
+
+    skills_transformed = skills_final
 
     if dry_run:
         logger.info(f"[DRY-RUN] Upsert {len(skills_transformed)} skills")


### PR DESCRIPTION
## Summary

- **Capa 1 (SQLite):** Filtra skills sin URI ESCO válido antes del INSERT en `save_skills_detalle()` — 282 rows fantasma eliminadas
- **Capa 2 (SQLite):** Dedup por URI en misma función, mayor score gana — 34 pares duplicados eliminados
- **Capa 3 (Supabase sync):** Dedup semántica por label normalizado (sin acentos) en `upsert_skills()` — atrapa variantes como "negocio electronico" vs "negocio electrónico"
- **Cleanup one-time:** Migración SQL ejecutada sobre SQLite existente (35,621 → 35,305 rows)

## Test plan

- [x] Verificar antes/después en SQLite: 0 sin URI, 0 duplicados
- [x] Syntax check ambos archivos modificados
- [x] Tests NLP validator pasan (33/33)
- [ ] Reprocesar oferta con duplicados conocidos y verificar resultado limpio
- [ ] Dry-run sync a Supabase para confirmar payload sin duplicados