### PR TITLE
feat(admin): /admin/laboratorio — staging de indicadores experimentales

### DIFF
--- a/docs/plan/02_ARQUITECTURA_PANTALLAS.md
+++ b/docs/plan/02_ARQUITECTURA_PANTALLAS.md
@@ -1,7 +1,7 @@
 # 2. Arquitectura de Pantallas
 
-> Ultima actualizacion: 2026-02-11
-> Versión: 2.1 — Modelo híbrido + filtros permanencia/tensión de demanda
+> Ultima actualizacion: 2026-02-26
+> Versión: 2.3 — Laboratorio de indicadores experimentales (P-31, P-31a)
 
 ## Referencias
 
@@ -39,6 +39,8 @@
 | - | `/admin/metricas` | ✅ Funcional | - |
 | - | `/admin/logs` | ⚠️ Prueba | Datos de prueba |
 | - | `/admin/configuracion` | ✅ Fase 1 | Solo lectura - [11_CONFIGURACION](./11_CONFIGURACION_ADMIN.md) |
+| P-31 | `/admin/laboratorio` | ✅ Funcional | Landing indicadores experimentales |
+| P-31a | `/admin/laboratorio/tension-demanda` | ✅ Funcional | V-16: scatter chart + tabla + metodología |
 
 ### Componentes Existentes
 
@@ -100,7 +102,9 @@ MOL Platform
     ├── /admin/logs ──────── P-23 Logs
     ├── /admin/configuracion P-24 Configuración
     ├── /admin/contenidos ── P-30 Gestión Contenidos (CMS)
-    └── /admin/arquitectura  P-25 Arquitectura Sistema
+    ├── /admin/arquitectura  P-25 Arquitectura Sistema
+    └── /admin/laboratorio ─ P-31 Laboratorio de Indicadores Experimentales
+        └── /tension-demanda P-31a Detalle Tensión de Demanda (V-16)
 ```
 
 ---
@@ -177,6 +181,8 @@ MOL Platform
 | P-24 | `/admin/configuracion` | U-ADMIN | ✅ Fase 1 | [11_CONFIGURACION](./11_CONFIGURACION_ADMIN.md) |
 | P-30 | `/admin/contenidos` | U-ADMIN | Por crear | [admin.md#p-30](./03_WIREFRAMES/admin.md#p-30-contenidos) |
 | P-25 | `/admin/arquitectura` | U-ADMIN | ✅ Existe (fixes v1.1) | [10_OBSERVABILIDAD](./10_OBSERVABILIDAD.md), [admin.md#p-25](./03_WIREFRAMES/admin.md#p-25-admin-arquitectura-adminarquitectura) |
+| P-31 | `/admin/laboratorio` | U-ADMIN | ✅ Existe | Staging de indicadores experimentales |
+| P-31a | `/admin/laboratorio/tension-demanda` | U-ADMIN | ✅ Existe | Detalle V-16: scatter chart + tabla + metodología |
 
 ---
 
@@ -189,8 +195,8 @@ MOL Platform
 | Checkout | 3 | 0 | 3 |
 | Tablero | 5 | 2 | 3 |
 | Cuenta | 3 | 0 | 3 |
-| Admin | 11 | 7 | 4 |
-| **TOTAL** | **30** | **10** | **20** |
+| Admin | 13 | 9 | 4 |
+| **TOTAL** | **32** | **12** | **20** |
 
 ---
 
@@ -316,7 +322,11 @@ app/
 │   └── facturacion/page.tsx  # P-16
 └── admin/                    # P-17 a P-25 (existente)
     ├── solicitudes/page.tsx  # P-29 (nuevo)
-    └── contenidos/page.tsx   # P-30 (nuevo)
+    ├── contenidos/page.tsx   # P-30 (nuevo)
+    └── laboratorio/
+        ├── page.tsx          # P-31 Landing indicadores experimentales
+        └── tension-demanda/
+            └── page.tsx      # P-31a Detalle V-16
 ```
 
 ---
@@ -330,3 +340,4 @@ app/
 | 2026-02-08 | 2.0.1 | P-25 code review: 7 fixes aplicados (Tailwind, env vars, error handling, sidebar dup, labels, imports) |
 | 2026-02-11 | 2.1 | Filtros permanencia y tensión de demanda en sidebar, componentes P-09 (scatter plot tensión) |
 | 2026-02-23 | 2.2 | AnimatedNav auth-aware (sesión → dashboard/logout), P-18 CRUD: C+R+U (editar rol) |
+| 2026-02-26 | 2.3 | P-31 Laboratorio de Indicadores Experimentales + P-31a Tensión de Demanda (V-16). Staging admin para indicadores antes de dashboard público. Total 32 pantallas |

--- a/fase3_dashboard/mol-dashboard/__tests__/component/tension-demanda-chart.test.tsx
+++ b/fase3_dashboard/mol-dashboard/__tests__/component/tension-demanda-chart.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  TensionDemandaChart,
+  CUADRANTE_COLORS,
+} from "../../components/laboratorio/TensionDemandaChart";
+import type { TensionOcupacion } from "../../lib/supabase";
+
+// Mock recharts — jsdom can't render SVG charts
+vi.mock("recharts", () => {
+  const MockResponsiveContainer = ({ children }: any) => (
+    <div data-testid="responsive-container">{children}</div>
+  );
+  const MockScatterChart = ({ children }: any) => (
+    <div data-testid="scatter-chart">{children}</div>
+  );
+  const MockScatter = ({ children }: any) => (
+    <div data-testid="scatter">{children}</div>
+  );
+  return {
+    ResponsiveContainer: MockResponsiveContainer,
+    ScatterChart: MockScatterChart,
+    Scatter: MockScatter,
+    XAxis: () => null,
+    YAxis: () => null,
+    ZAxis: () => null,
+    CartesianGrid: () => null,
+    Tooltip: () => null,
+    ReferenceLine: () => null,
+    Cell: () => null,
+  };
+});
+
+const mockData: TensionOcupacion[] = [
+  {
+    isco_code: "2514",
+    isco_label: "Programadores de aplicaciones",
+    total_posiciones: 120,
+    total_ofertas: 180,
+    persistencia: 75.5,
+    insistencia: 60.2,
+    cuadrante: "CRITICO",
+  },
+  {
+    isco_code: "3323",
+    isco_label: "Compradores",
+    total_posiciones: 45,
+    total_ofertas: 50,
+    persistencia: 30.0,
+    insistencia: 20.0,
+    cuadrante: "FLUIDO",
+  },
+  {
+    isco_code: "5223",
+    isco_label: "Vendedores de tiendas",
+    total_posiciones: 80,
+    total_ofertas: 95,
+    persistencia: 65.0,
+    insistencia: 35.0,
+    cuadrante: "URGENTE",
+  },
+  {
+    isco_code: "4110",
+    isco_label: "Oficinistas generales",
+    total_posiciones: 30,
+    total_ofertas: 40,
+    persistencia: 20.0,
+    insistencia: 70.0,
+    cuadrante: "PASIVO",
+  },
+];
+
+describe("TensionDemandaChart", () => {
+  it("renders chart container", () => {
+    render(<TensionDemandaChart data={mockData} />);
+    expect(screen.getByTestId("tension-chart-container")).toBeInTheDocument();
+  });
+
+  it("renders scatter chart", () => {
+    render(<TensionDemandaChart data={mockData} />);
+    expect(screen.getByTestId("scatter-chart")).toBeInTheDocument();
+  });
+
+  it("renders legend with counts per cuadrante", () => {
+    render(<TensionDemandaChart data={mockData} />);
+    const legend = screen.getByTestId("tension-legend");
+    expect(legend).toBeInTheDocument();
+
+    expect(legend.textContent).toContain("CRITICO (1)");
+    expect(legend.textContent).toContain("URGENTE (1)");
+    expect(legend.textContent).toContain("PASIVO (1)");
+    expect(legend.textContent).toContain("FLUIDO (1)");
+  });
+
+  it("handles empty data", () => {
+    render(<TensionDemandaChart data={[]} />);
+    const legend = screen.getByTestId("tension-legend");
+    expect(legend.textContent).toContain("CRITICO (0)");
+    expect(legend.textContent).toContain("FLUIDO (0)");
+  });
+
+  it("CUADRANTE_COLORS has exactly 4 entries", () => {
+    expect(Object.keys(CUADRANTE_COLORS)).toHaveLength(4);
+    expect(CUADRANTE_COLORS).toHaveProperty("CRITICO");
+    expect(CUADRANTE_COLORS).toHaveProperty("URGENTE");
+    expect(CUADRANTE_COLORS).toHaveProperty("PASIVO");
+    expect(CUADRANTE_COLORS).toHaveProperty("FLUIDO");
+  });
+});

--- a/fase3_dashboard/mol-dashboard/app/admin/laboratorio/page.tsx
+++ b/fase3_dashboard/mol-dashboard/app/admin/laboratorio/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import Link from "next/link";
+import { FlaskConical, Zap, ArrowRight, Database, Calendar } from "lucide-react";
+
+const INDICATORS = [
+  {
+    slug: "tension-demanda",
+    title: "Tension de Demanda",
+    description:
+      "Persistencia x Insistencia por ocupacion ISCO. Identifica demanda critica, urgente, pasiva o fluida.",
+    status: "experimental" as const,
+    href: "/admin/laboratorio/tension-demanda",
+    icon: Zap,
+    dataSource: "tension_ocupaciones",
+    addedDate: "2026-02",
+  },
+];
+
+const STATUS_STYLES = {
+  experimental: {
+    label: "Experimental",
+    bg: "bg-amber-100",
+    text: "text-amber-800",
+    border: "border-amber-200",
+    dot: "bg-amber-500",
+  },
+  beta: {
+    label: "Beta",
+    bg: "bg-blue-100",
+    text: "text-blue-800",
+    border: "border-blue-200",
+    dot: "bg-blue-500",
+  },
+  production: {
+    label: "Produccion",
+    bg: "bg-green-100",
+    text: "text-green-800",
+    border: "border-green-200",
+    dot: "bg-green-500",
+  },
+};
+
+export default function LaboratorioPage() {
+  return (
+    <div className="p-8 max-w-6xl mx-auto">
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center gap-3 mb-2">
+          <div className="bg-gradient-to-br from-purple-500 to-purple-600 rounded-lg p-2.5 shadow-md">
+            <FlaskConical className="w-6 h-6 text-white" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">
+              Laboratorio de Indicadores
+            </h1>
+            <p className="text-sm text-gray-500">
+              Indicadores experimentales en fase de prueba antes de pasar al
+              dashboard publico
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div className="flex items-center gap-4 mb-6 text-xs text-gray-500">
+        {Object.entries(STATUS_STYLES).map(([key, style]) => (
+          <div key={key} className="flex items-center gap-1.5">
+            <div className={`w-2 h-2 rounded-full ${style.dot}`} />
+            <span>{style.label}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Indicator Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {INDICATORS.map((indicator) => {
+          const statusStyle = STATUS_STYLES[indicator.status];
+          const Icon = indicator.icon;
+          return (
+            <div
+              key={indicator.slug}
+              className="bg-white border border-gray-200 rounded-xl p-6 shadow-sm hover:shadow-md transition-shadow duration-300 flex flex-col"
+            >
+              <div className="flex items-start justify-between mb-4">
+                <div className="bg-gradient-to-br from-gray-100 to-gray-200 rounded-lg p-2.5">
+                  <Icon className="w-5 h-5 text-gray-700" />
+                </div>
+                <span
+                  className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ${statusStyle.bg} ${statusStyle.text} ${statusStyle.border} border`}
+                >
+                  <span
+                    className={`w-1.5 h-1.5 rounded-full ${statusStyle.dot}`}
+                  />
+                  {statusStyle.label}
+                </span>
+              </div>
+
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                {indicator.title}
+              </h3>
+              <p className="text-sm text-gray-600 mb-4 flex-1">
+                {indicator.description}
+              </p>
+
+              <div className="flex items-center gap-4 text-xs text-gray-400 mb-4">
+                <div className="flex items-center gap-1">
+                  <Database className="w-3.5 h-3.5" />
+                  <span>{indicator.dataSource}</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <Calendar className="w-3.5 h-3.5" />
+                  <span>{indicator.addedDate}</span>
+                </div>
+              </div>
+
+              <Link
+                href={indicator.href}
+                className="flex items-center justify-center gap-2 w-full px-4 py-2.5 bg-gray-900 text-white rounded-lg text-sm font-medium hover:bg-gray-800 transition-colors"
+              >
+                Ver indicador
+                <ArrowRight className="w-4 h-4" />
+              </Link>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Empty state hint */}
+      {INDICATORS.length === 1 && (
+        <div className="mt-8 text-center text-sm text-gray-400">
+          Nuevos indicadores se agregan aqui antes de promoverlos al dashboard
+          publico.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/fase3_dashboard/mol-dashboard/app/admin/laboratorio/tension-demanda/page.tsx
+++ b/fase3_dashboard/mol-dashboard/app/admin/laboratorio/tension-demanda/page.tsx
@@ -1,0 +1,395 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  Loader2,
+  AlertCircle,
+  Zap,
+  Users,
+  AlertTriangle,
+  BarChart3,
+  ChevronUp,
+  ChevronDown,
+} from "lucide-react";
+import { getTensionOcupaciones, TensionOcupacion } from "@/lib/supabase";
+import { ChartContainer } from "@/components/ChartContainer";
+import {
+  TensionDemandaChart,
+  CUADRANTE_COLORS,
+} from "@/components/laboratorio/TensionDemandaChart";
+
+// Inline InsightList/InsightItem — trivial, extracted when a 3rd consumer appears
+const InsightList = ({ children }: { children: React.ReactNode }) => (
+  <ul className="space-y-3 list-none">{children}</ul>
+);
+
+const InsightItem = ({
+  text,
+  highlight,
+}: {
+  text: string;
+  highlight?: boolean;
+}) => (
+  <li
+    className={`flex items-start gap-3 transition-all duration-200 ${highlight ? "font-semibold" : ""}`}
+  >
+    <span
+      className={`mt-1.5 h-1.5 w-1.5 rounded-full flex-shrink-0 ${highlight ? "bg-amber-600" : "bg-gray-400"}`}
+    />
+    <p
+      className={`text-sm leading-relaxed flex-1 ${highlight ? "text-gray-900" : "text-gray-700"}`}
+    >
+      {text}
+    </p>
+  </li>
+);
+
+type SortKey = "isco_code" | "isco_label" | "total_posiciones" | "total_ofertas" | "persistencia" | "insistencia" | "cuadrante";
+
+export default function TensionDemandaPage() {
+  const [data, setData] = useState<TensionOcupacion[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useState<SortKey>("total_posiciones");
+  const [sortDesc, setSortDesc] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        setLoading(true);
+        const result = await getTensionOcupaciones();
+        setData(result);
+      } catch (err) {
+        console.error("Error loading tension data:", err);
+        setError("Error al cargar datos de tension de demanda.");
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  const cuadranteCounts: Record<string, number> = {};
+  data.forEach((d) => {
+    cuadranteCounts[d.cuadrante] = (cuadranteCounts[d.cuadrante] || 0) + 1;
+  });
+
+  const totalPosiciones = data.reduce((s, d) => s + d.total_posiciones, 0);
+
+  const sortedData = useMemo(() => {
+    const sorted = [...data].sort((a, b) => {
+      const aVal = a[sortKey];
+      const bVal = b[sortKey];
+      if (typeof aVal === "number" && typeof bVal === "number") {
+        return sortDesc ? bVal - aVal : aVal - bVal;
+      }
+      return sortDesc
+        ? String(bVal).localeCompare(String(aVal))
+        : String(aVal).localeCompare(String(bVal));
+    });
+    return sorted;
+  }, [data, sortKey, sortDesc]);
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDesc(!sortDesc);
+    } else {
+      setSortKey(key);
+      setSortDesc(true);
+    }
+  };
+
+  const SortIcon = ({ columnKey }: { columnKey: SortKey }) => {
+    if (sortKey !== columnKey)
+      return <ChevronDown className="w-3 h-3 text-gray-300" />;
+    return sortDesc ? (
+      <ChevronDown className="w-3 h-3 text-gray-700" />
+    ) : (
+      <ChevronUp className="w-3 h-3 text-gray-700" />
+    );
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-[400px] flex items-center justify-center">
+        <Loader2 className="w-8 h-8 animate-spin text-blue-600" />
+        <span className="ml-3 text-gray-600">Cargando datos de tension...</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-8 max-w-6xl mx-auto">
+        <div className="bg-red-50 border border-red-200 rounded-xl p-6 flex items-start gap-3">
+          <AlertCircle className="w-5 h-5 text-red-600 mt-0.5" />
+          <div>
+            <p className="font-semibold text-red-800">Error</p>
+            <p className="text-sm text-red-700">{error}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-8 max-w-6xl mx-auto space-y-6">
+      {/* Header */}
+      <div>
+        <Link
+          href="/admin/laboratorio"
+          className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 mb-3 transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Laboratorio
+        </Link>
+        <div className="flex items-center gap-3">
+          <h1 className="text-2xl font-bold text-gray-900">
+            Tension de Demanda
+          </h1>
+          <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-amber-100 text-amber-800 border border-amber-200">
+            <span className="w-1.5 h-1.5 rounded-full bg-amber-500" />
+            Experimental
+          </span>
+        </div>
+        <p className="text-sm text-gray-500 mt-1">
+          Indicador V-16: Persistencia x Insistencia por ocupacion ISCO
+        </p>
+      </div>
+
+      {/* Stats Row */}
+      <div className="grid grid-cols-4 gap-4">
+        <div className="bg-gradient-to-br from-blue-50 to-blue-100 rounded-xl p-5 shadow-sm">
+          <div className="flex items-center gap-2 mb-1">
+            <BarChart3 className="w-4 h-4 text-blue-600" />
+            <span className="text-xs font-semibold text-gray-500 uppercase">
+              Ocupaciones
+            </span>
+          </div>
+          <p className="text-3xl font-bold text-gray-900">{data.length}</p>
+        </div>
+        <div className="bg-gradient-to-br from-red-50 to-red-100 rounded-xl p-5 shadow-sm">
+          <div className="flex items-center gap-2 mb-1">
+            <AlertTriangle className="w-4 h-4 text-red-600" />
+            <span className="text-xs font-semibold text-gray-500 uppercase">
+              Critico
+            </span>
+          </div>
+          <p className="text-3xl font-bold text-red-700">
+            {cuadranteCounts["CRITICO"] || 0}
+          </p>
+        </div>
+        <div className="bg-gradient-to-br from-orange-50 to-orange-100 rounded-xl p-5 shadow-sm">
+          <div className="flex items-center gap-2 mb-1">
+            <Zap className="w-4 h-4 text-orange-600" />
+            <span className="text-xs font-semibold text-gray-500 uppercase">
+              Urgente
+            </span>
+          </div>
+          <p className="text-3xl font-bold text-orange-700">
+            {cuadranteCounts["URGENTE"] || 0}
+          </p>
+        </div>
+        <div className="bg-gradient-to-br from-purple-50 to-purple-100 rounded-xl p-5 shadow-sm">
+          <div className="flex items-center gap-2 mb-1">
+            <Users className="w-4 h-4 text-purple-600" />
+            <span className="text-xs font-semibold text-gray-500 uppercase">
+              Total posiciones
+            </span>
+          </div>
+          <p className="text-3xl font-bold text-gray-900">
+            {totalPosiciones.toLocaleString()}
+          </p>
+        </div>
+      </div>
+
+      {/* Chart with Insights */}
+      <ChartContainer
+        title="Tension de demanda por ocupacion"
+        subtitle={`${data.length} ocupaciones — 4 cuadrantes`}
+        insights={
+          <InsightList>
+            {cuadranteCounts["CRITICO"] ? (
+              <InsightItem
+                text={`${cuadranteCounts["CRITICO"]} ocupaciones en estado critico (alta persistencia + alta insistencia)`}
+                highlight
+              />
+            ) : null}
+            {cuadranteCounts["URGENTE"] ? (
+              <InsightItem
+                text={`${cuadranteCounts["URGENTE"]} urgentes: persisten pero no se republican`}
+              />
+            ) : null}
+            <InsightItem
+              text={`${cuadranteCounts["FLUIDO"] || 0} ocupaciones con demanda fluida (se cubren rapidamente)`}
+            />
+            <InsightItem
+              text={`Umbral: 50% en ambos ejes divide los 4 cuadrantes`}
+            />
+          </InsightList>
+        }
+      >
+        <TensionDemandaChart data={data} />
+      </ChartContainer>
+
+      {/* Methodology */}
+      <div className="bg-white border border-gray-200 rounded-xl p-6 shadow-sm">
+        <h3 className="text-lg font-bold text-gray-900 mb-4">Metodologia</h3>
+        <div className="grid grid-cols-2 gap-6 text-sm text-gray-700">
+          <div>
+            <h4 className="font-semibold text-gray-900 mb-2">
+              Persistencia (eje X)
+            </h4>
+            <p>
+              Porcentaje de posiciones cuya ventana de publicacion supera los 45
+              dias. Valores altos indican que las vacantes permanecen abiertas
+              mucho tiempo, sugiriendo dificultad para cubrir la posicion.
+            </p>
+          </div>
+          <div>
+            <h4 className="font-semibold text-gray-900 mb-2">
+              Insistencia (eje Y)
+            </h4>
+            <p>
+              Porcentaje de posiciones que fueron republicadas (mismo aviso
+              publicado multiples veces). Valores altos sugieren que la empresa
+              necesita re-publicar porque no encuentra candidatos.
+            </p>
+          </div>
+          <div className="col-span-2">
+            <h4 className="font-semibold text-gray-900 mb-2">Cuadrantes</h4>
+            <div className="grid grid-cols-4 gap-3">
+              {[
+                {
+                  name: "CRITICO",
+                  desc: "Alta persistencia + alta insistencia. Vacantes dificiles de cubrir que se republican constantemente.",
+                },
+                {
+                  name: "URGENTE",
+                  desc: "Alta persistencia + baja insistencia. Permanecen abiertas mucho tiempo pero no se re-publican.",
+                },
+                {
+                  name: "PASIVO",
+                  desc: "Baja persistencia + alta insistencia. Se cubren rapido pero se re-publican (alta rotacion).",
+                },
+                {
+                  name: "FLUIDO",
+                  desc: "Baja persistencia + baja insistencia. Mercado funcional: se publican y cubren sin friccion.",
+                },
+              ].map((q) => (
+                <div
+                  key={q.name}
+                  className="border rounded-lg p-3"
+                  style={{
+                    borderColor:
+                      CUADRANTE_COLORS[q.name] || "#e5e7eb",
+                  }}
+                >
+                  <div className="flex items-center gap-1.5 mb-1">
+                    <div
+                      className="w-2.5 h-2.5 rounded-full"
+                      style={{
+                        backgroundColor:
+                          CUADRANTE_COLORS[q.name] || "#6b7280",
+                      }}
+                    />
+                    <span className="text-xs font-bold">{q.name}</span>
+                  </div>
+                  <p className="text-xs text-gray-600">{q.desc}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+        <div className="px-6 py-4 border-b border-gray-200">
+          <h3 className="text-lg font-bold text-gray-900">
+            Detalle por ocupacion
+          </h3>
+          <p className="text-sm text-gray-500">
+            {data.length} ocupaciones — click en columna para ordenar
+          </p>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-gray-50 border-b border-gray-200">
+                {[
+                  { key: "isco_code" as SortKey, label: "ISCO" },
+                  { key: "isco_label" as SortKey, label: "Ocupacion" },
+                  { key: "total_posiciones" as SortKey, label: "Posiciones" },
+                  { key: "total_ofertas" as SortKey, label: "Ofertas" },
+                  { key: "persistencia" as SortKey, label: "Persistencia" },
+                  { key: "insistencia" as SortKey, label: "Insistencia" },
+                  { key: "cuadrante" as SortKey, label: "Cuadrante" },
+                ].map((col) => (
+                  <th
+                    key={col.key}
+                    onClick={() => handleSort(col.key)}
+                    className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase cursor-pointer hover:bg-gray-100 transition-colors select-none"
+                  >
+                    <div className="flex items-center gap-1">
+                      {col.label}
+                      <SortIcon columnKey={col.key} />
+                    </div>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {sortedData.map((row) => (
+                <tr
+                  key={row.isco_code}
+                  className="hover:bg-gray-50 transition-colors"
+                >
+                  <td className="px-4 py-3 font-mono text-xs text-gray-500">
+                    {row.isco_code}
+                  </td>
+                  <td className="px-4 py-3 font-medium text-gray-900">
+                    {row.isco_label}
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    {row.total_posiciones}
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    {row.total_ofertas}
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    {row.persistencia}%
+                  </td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    {row.insistencia}%
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-semibold"
+                      style={{
+                        backgroundColor: `${CUADRANTE_COLORS[row.cuadrante] || "#6b7280"}15`,
+                        color:
+                          CUADRANTE_COLORS[row.cuadrante] || "#6b7280",
+                      }}
+                    >
+                      <span
+                        className="w-1.5 h-1.5 rounded-full"
+                        style={{
+                          backgroundColor:
+                            CUADRANTE_COLORS[row.cuadrante] || "#6b7280",
+                        }}
+                      />
+                      {row.cuadrante}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/fase3_dashboard/mol-dashboard/app/admin/layout.tsx
+++ b/fase3_dashboard/mol-dashboard/app/admin/layout.tsx
@@ -14,7 +14,8 @@ import {
   Loader2,
   MessageSquare,
   Target,
-  Network
+  Network,
+  FlaskConical,
 } from "lucide-react";
 import { createBrowserClient } from "@/lib/supabase/browser";
 
@@ -24,6 +25,7 @@ const adminNavItems = [
   { href: "/admin/usuarios", label: "Usuarios", icon: Users },
   { href: "/admin/issues", label: "Issues", icon: MessageSquare },
   { href: "/admin/skills", label: "Skills Intelligence", icon: Target },
+  { href: "/admin/laboratorio", label: "Laboratorio", icon: FlaskConical, matchMode: "startsWith" as const },
   { href: "/admin/scraping", label: "Scraping", icon: Database },
   { href: "/admin/metricas", label: "Métricas", icon: BarChart3 },
   { href: "/admin/logs", label: "Logs", icon: FileText },
@@ -93,7 +95,9 @@ export default function AdminLayout({
         <nav className="flex-1 p-4">
           <ul className="space-y-1">
             {adminNavItems.map((item, index) => {
-              const isActive = pathname === item.href;
+              const isActive = item.matchMode === "startsWith"
+                ? pathname.startsWith(item.href)
+                : pathname === item.href;
               return (
                 <li key={`${item.href}-${index}`}>
                   <Link

--- a/fase3_dashboard/mol-dashboard/components/laboratorio/TensionDemandaChart.tsx
+++ b/fase3_dashboard/mol-dashboard/components/laboratorio/TensionDemandaChart.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import {
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  ZAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+  Cell,
+} from "recharts";
+import type { TensionOcupacion } from "@/lib/supabase";
+
+export const CUADRANTE_COLORS: Record<string, string> = {
+  CRITICO: "#ef4444",
+  URGENTE: "#f97316",
+  PASIVO: "#eab308",
+  FLUIDO: "#22c55e",
+};
+
+function TensionTooltip({ active, payload }: any) {
+  if (!active || !payload?.length) return null;
+  const d = payload[0].payload as TensionOcupacion;
+  return (
+    <div className="bg-white px-4 py-3 shadow-lg rounded-lg border border-gray-200 max-w-xs">
+      <p className="font-semibold text-gray-900 text-sm">{d.isco_label}</p>
+      <p className="text-xs text-gray-500 mb-2">ISCO {d.isco_code}</p>
+      <div className="space-y-1 text-sm">
+        <p>
+          Persistencia: <span className="font-bold">{d.persistencia}%</span>
+        </p>
+        <p>
+          Insistencia: <span className="font-bold">{d.insistencia}%</span>
+        </p>
+        <p>
+          Posiciones: <span className="font-bold">{d.total_posiciones}</span>
+        </p>
+        <p>
+          Ofertas: <span className="font-bold">{d.total_ofertas}</span>
+        </p>
+        <p
+          className="font-semibold"
+          style={{ color: CUADRANTE_COLORS[d.cuadrante] || "#6b7280" }}
+        >
+          {d.cuadrante}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+interface TensionDemandaChartProps {
+  data: TensionOcupacion[];
+}
+
+export function TensionDemandaChart({ data }: TensionDemandaChartProps) {
+  const cuadranteCounts: Record<string, number> = {};
+  data.forEach((d) => {
+    cuadranteCounts[d.cuadrante] = (cuadranteCounts[d.cuadrante] || 0) + 1;
+  });
+
+  return (
+    <div data-testid="tension-chart-container">
+      <ResponsiveContainer width="100%" height={400}>
+        <ScatterChart
+          margin={{ top: 20, right: 30, left: 20, bottom: 20 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+          <XAxis
+            type="number"
+            dataKey="persistencia"
+            name="Persistencia"
+            domain={[0, 100]}
+            tickFormatter={(v) => `${v}%`}
+            label={{
+              value: "Persistencia (%)",
+              position: "insideBottom",
+              offset: -10,
+              style: { fill: "#6b7280", fontSize: 12 },
+            }}
+          />
+          <YAxis
+            type="number"
+            dataKey="insistencia"
+            name="Insistencia"
+            domain={[0, 100]}
+            tickFormatter={(v) => `${v}%`}
+            label={{
+              value: "Insistencia (%)",
+              angle: -90,
+              position: "insideLeft",
+              offset: 10,
+              style: { fill: "#6b7280", fontSize: 12 },
+            }}
+          />
+          <ZAxis
+            type="number"
+            dataKey="total_posiciones"
+            range={[40, 400]}
+            name="Posiciones"
+          />
+          <ReferenceLine x={50} stroke="#9ca3af" strokeDasharray="5 5" />
+          <ReferenceLine y={50} stroke="#9ca3af" strokeDasharray="5 5" />
+          <Tooltip content={<TensionTooltip />} />
+          <Scatter data={data} fill="#8884d8">
+            {data.map((entry, index) => (
+              <Cell
+                key={index}
+                fill={CUADRANTE_COLORS[entry.cuadrante] || "#6b7280"}
+                fillOpacity={0.7}
+              />
+            ))}
+          </Scatter>
+        </ScatterChart>
+      </ResponsiveContainer>
+      <div
+        className="flex items-center justify-center gap-6 mt-2 text-xs"
+        data-testid="tension-legend"
+      >
+        {Object.entries(CUADRANTE_COLORS).map(([name, color]) => (
+          <div key={name} className="flex items-center gap-1.5">
+            <div
+              className="w-3 h-3 rounded-full"
+              style={{ backgroundColor: color }}
+            />
+            <span className="text-gray-600">
+              {name} ({cuadranteCounts[name] || 0})
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/fase3_dashboard/mol-dashboard/lib/supabase.ts
+++ b/fase3_dashboard/mol-dashboard/lib/supabase.ts
@@ -1229,6 +1229,32 @@ export async function getIssuesByOferta(id_oferta: string): Promise<Issue[]> {
   return data || []
 }
 
+// ========== TENSIÓN DE DEMANDA (V-16) ==========
+
+export interface TensionOcupacion {
+  isco_code: string
+  isco_label: string
+  total_posiciones: number
+  total_ofertas: number
+  persistencia: number
+  insistencia: number
+  cuadrante: string
+}
+
+export async function getTensionOcupaciones(): Promise<TensionOcupacion[]> {
+  const client = getSupabaseClient()
+  if (!client) return []
+  const { data, error } = await client
+    .from('tension_ocupaciones')
+    .select('*')
+    .order('total_posiciones', { ascending: false })
+  if (error) {
+    console.error('Error fetching tension:', error)
+    return []
+  }
+  return data || []
+}
+
 // ========== FUNCIONES PARA PERFIL CONSOLIDADO ==========
 
 import { ConsolidatedProfile, ConsolidatedProfilesIndex } from './types'

--- a/scripts/exports/supabase_schema.sql
+++ b/scripts/exports/supabase_schema.sql
@@ -211,3 +211,35 @@ COMMENT ON TABLE ofertas IS 'Ofertas laborales validadas del pipeline MOL';
 COMMENT ON TABLE ofertas_skills IS 'Skills extraídas por oferta con clasificación ESCO';
 COMMENT ON TABLE esco_occupations IS 'Catálogo ESCO ocupaciones (subset usado)';
 COMMENT ON TABLE esco_skills IS 'Catálogo ESCO skills (subset usado)';
+
+-- ============================================================
+-- Tensión de Demanda por Ocupación (V-16)
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS tension_ocupaciones (
+    isco_code TEXT PRIMARY KEY,
+    isco_label TEXT,
+    total_posiciones INTEGER NOT NULL,
+    total_ofertas INTEGER NOT NULL,
+    persistencia NUMERIC(5,2) NOT NULL,
+    insistencia NUMERIC(5,2) NOT NULL,
+    cuadrante TEXT NOT NULL,
+    calculado_en TIMESTAMPTZ DEFAULT NOW(),
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE tension_ocupaciones ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Public read tension" ON tension_ocupaciones;
+CREATE POLICY "Public read tension" ON tension_ocupaciones FOR SELECT USING (true);
+
+CREATE INDEX IF NOT EXISTS idx_tension_cuadrante ON tension_ocupaciones(cuadrante);
+
+DROP TRIGGER IF EXISTS update_tension_updated_at ON tension_ocupaciones;
+CREATE TRIGGER update_tension_updated_at
+    BEFORE UPDATE ON tension_ocupaciones
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+COMMENT ON TABLE tension_ocupaciones IS 'Indicador V-16: Tensión de Demanda por ocupación (persistencia x insistencia)';

--- a/scripts/exports/sync_to_supabase.py
+++ b/scripts/exports/sync_to_supabase.py
@@ -62,6 +62,7 @@ TABLE_OFERTAS = 'ofertas_dashboard'
 TABLE_SKILLS = 'ofertas_skills'
 TABLE_SKILLS_CATALOG = 'skills'
 TABLE_OCUPACIONES = 'ocupaciones_esco'
+TABLE_TENSION = 'tension_ocupaciones'
 
 
 def load_config() -> Dict[str, str]:
@@ -1330,6 +1331,144 @@ def sync_sistema_estado(client, conn: sqlite3.Connection, dry_run: bool = False)
 
 
 # ============================================================
+# TENSIÓN DE DEMANDA (V-16)
+# ============================================================
+
+def calcular_tension_ocupaciones(conn: sqlite3.Connection) -> List[Dict[str, Any]]:
+    """
+    Calcula indicadores de tensión de demanda por ocupación ISCO.
+
+    Indicadores:
+    - Persistencia: % de posiciones con ventana de publicación >45 días
+    - Insistencia: % de posiciones que fueron republicadas
+    - Cuadrante: CRITICO (alta-alta), URGENTE (alta-baja), PASIVO (baja-alta), FLUIDO (baja-baja)
+
+    Una "posición" = un grupo_republicacion (ofertas agrupadas que son la misma vacante)
+    Ofertas sin grupo = cada una es su propia posición.
+    """
+    query = """
+    WITH ofertas_validadas AS (
+        SELECT
+            o.id_oferta,
+            m.isco_code,
+            m.isco_label,
+            o.dias_publicada,
+            COALESCE(o.grupo_republicacion, o.id_oferta) AS posicion_id,
+            CASE WHEN o.grupo_republicacion IS NOT NULL THEN 1 ELSE 0 END AS es_republicada
+        FROM ofertas o
+        INNER JOIN ofertas_esco_matching m ON o.id_oferta = m.id_oferta
+        WHERE m.estado_validacion IN ('validado', 'validado_claude', 'validado_humano')
+          AND m.isco_code IS NOT NULL
+    ),
+    posiciones AS (
+        SELECT
+            isco_code,
+            isco_label,
+            posicion_id,
+            MAX(dias_publicada) AS ventana_dias,
+            MAX(es_republicada) AS fue_republicada,
+            COUNT(*) AS ofertas_en_posicion
+        FROM ofertas_validadas
+        GROUP BY isco_code, isco_label, posicion_id
+    ),
+    por_isco AS (
+        SELECT
+            isco_code,
+            MAX(isco_label) AS isco_label,
+            COUNT(DISTINCT posicion_id) AS total_posiciones,
+            SUM(ofertas_en_posicion) AS total_ofertas,
+            ROUND(
+                100.0 * SUM(CASE WHEN ventana_dias > 45 THEN 1 ELSE 0 END) / COUNT(*),
+                2
+            ) AS persistencia,
+            ROUND(
+                100.0 * SUM(CASE WHEN fue_republicada = 1 THEN 1 ELSE 0 END) / COUNT(*),
+                2
+            ) AS insistencia
+        FROM posiciones
+        GROUP BY isco_code
+        HAVING COUNT(DISTINCT posicion_id) >= 1
+    )
+    SELECT
+        isco_code,
+        isco_label,
+        total_posiciones,
+        total_ofertas,
+        persistencia,
+        insistencia,
+        CASE
+            WHEN persistencia >= 50 AND insistencia >= 50 THEN 'CRITICO'
+            WHEN persistencia >= 50 AND insistencia < 50 THEN 'URGENTE'
+            WHEN persistencia < 50 AND insistencia >= 50 THEN 'PASIVO'
+            ELSE 'FLUIDO'
+        END AS cuadrante
+    FROM por_isco
+    ORDER BY total_posiciones DESC
+    """
+
+    cursor = conn.execute(query)
+    rows = cursor.fetchall()
+
+    resultados = []
+    for row in rows:
+        resultados.append({
+            'isco_code': row['isco_code'],
+            'isco_label': row['isco_label'],
+            'total_posiciones': row['total_posiciones'],
+            'total_ofertas': row['total_ofertas'],
+            'persistencia': float(row['persistencia']),
+            'insistencia': float(row['insistencia']),
+            'cuadrante': row['cuadrante'],
+            'calculado_en': datetime.now().isoformat(),
+        })
+
+    logger.info(f"Tensión calculada: {len(resultados)} ocupaciones")
+    cuadrantes = {}
+    for r in resultados:
+        cuadrantes[r['cuadrante']] = cuadrantes.get(r['cuadrante'], 0) + 1
+    for c, n in sorted(cuadrantes.items()):
+        logger.info(f"  {c}: {n}")
+
+    return resultados
+
+
+def sync_tension_ocupaciones(client, conn: sqlite3.Connection, dry_run: bool = False) -> int:
+    """
+    Sincroniza tensión de demanda a Supabase.
+    Trunca y reinserta (datos calculados, no incrementales).
+    """
+    resultados = calcular_tension_ocupaciones(conn)
+
+    if not resultados:
+        logger.warning("No hay datos de tensión para sincronizar")
+        return 0
+
+    if dry_run:
+        logger.info(f"[DRY-RUN] Sync {len(resultados)} ocupaciones de tensión")
+        return len(resultados)
+
+    # Truncar tabla (delete all rows - Supabase workaround)
+    try:
+        client.table(TABLE_TENSION).delete().neq('isco_code', '__none__').execute()
+    except Exception as e:
+        logger.warning(f"Error truncando tension_ocupaciones: {e}")
+
+    # Insertar en batches
+    total = 0
+    for i in range(0, len(resultados), BATCH_SIZE):
+        batch = resultados[i:i + BATCH_SIZE]
+        try:
+            client.table(TABLE_TENSION).insert(batch).execute()
+            total += len(batch)
+        except Exception as e:
+            logger.error(f"Error insertando tensión batch {i // BATCH_SIZE + 1}: {e}")
+            raise
+
+    logger.info(f"Tensión sincronizada: {total} ocupaciones")
+    return total
+
+
+# ============================================================
 # ESTADÍSTICAS
 # ============================================================
 
@@ -1557,6 +1696,10 @@ Ejemplos:
         logger.info("Sincronizando estado del sistema...")
         sync_sistema_estado(client, conn, dry_run=args.dry_run)
 
+        # Tensión de demanda por ocupación (V-16)
+        logger.info("Calculando tensión de demanda...")
+        n_tension = sync_tension_ocupaciones(client, conn, dry_run=args.dry_run)
+
         # Resumen
         print("\n" + "="*60)
         print("RESUMEN" + (" [DRY-RUN]" if args.dry_run else ""))
@@ -1566,6 +1709,7 @@ Ejemplos:
         print(f"Ocupaciones ESCO:         {n_ocup}")
         print(f"Skills ESCO:              {n_esco}")
         print(f"Issues sincronizados:     {n_issues}")
+        print(f"Tensión ocupaciones:      {n_tension}")
         print("="*60)
 
         if not args.dry_run:


### PR DESCRIPTION
## Summary

- Add `/admin/laboratorio` (P-31) as admin staging area for experimental indicators before they go to the public dashboard
- Implement **Tension de Demanda (V-16)** as first indicator: scatter chart (persistencia × insistencia), stats row, methodology section, sortable table
- Cherry-pick backend from `feature/tension-demanda`: `TensionOcupacion` interface, `getTensionOcupaciones()`, `tension_ocupaciones` table DDL, `calcular_tension_ocupaciones()` + `sync_tension_ocupaciones()` in sync script
- Add `Laboratorio` nav item with `startsWith` active link detection for sub-pages
- Register P-31 and P-31a in `02_ARQUITECTURA_PANTALLAS.md` (32 total screens)

## Files

**Created (4):**
- `components/laboratorio/TensionDemandaChart.tsx` — presentational ScatterChart component
- `app/admin/laboratorio/page.tsx` — landing with indicator cards + status badges
- `app/admin/laboratorio/tension-demanda/page.tsx` — detail: stats + chart + methodology + table
- `__tests__/component/tension-demanda-chart.test.tsx` — 5 tests

**Modified (5):**
- `app/admin/layout.tsx` — sidebar nav + active detection fix
- `lib/supabase.ts` — interface + query
- `scripts/exports/supabase_schema.sql` — DDL + RLS + index
- `scripts/exports/sync_to_supabase.py` — calc + sync functions
- `docs/plan/02_ARQUITECTURA_PANTALLAS.md` — P-31, P-31a registration

## What is NOT touched from feature/tension-demanda

`PanoramaGeneral.tsx`, `Sidebar.tsx`, `ActiveFilters.tsx`, `dashboard/page.tsx`, `types.ts` — all public dashboard changes stay in the original branch until the indicator is promoted from experimental to production.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 202 tests passed (19 files), 0 regressions
- [ ] `/admin/laboratorio` → shows Tension de Demanda card with amber "Experimental" badge
- [ ] Click card → `/admin/laboratorio/tension-demanda` → scatter chart, 4 KPIs, methodology, sortable table
- [ ] Sidebar highlights "Laboratorio" on both pages
- [ ] `/dashboard` → NO tension chart (PanoramaGeneral untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)