### PR TITLE
feat(dashboard): add 5 public pages and wire footer links

### DIFF
--- a/docs/plan/02_ARQUITECTURA_PANTALLAS.md
+++ b/docs/plan/02_ARQUITECTURA_PANTALLAS.md
@@ -1,7 +1,7 @@
 # 2. Arquitectura de Pantallas
 
-> Ultima actualizacion: 2026-03-03
-> Versión: 2.4 — Acceso gated, oficina empleo, contenido placeholder
+> Ultima actualizacion: 2026-03-04
+> Versión: 2.5 — 5 páginas públicas (landings + legal)
 
 ## Referencias
 
@@ -64,7 +64,12 @@ MOL Platform
 │   ├── /informes ────────── P-03 Informes (preview para visitantes)
 │   ├── /login ───────────── P-04 Login
 │   ├── /registro ────────── P-05 Registro (libre, sin plan)
-│   └── /skills ──────────── (existente, versión pública)
+│   ├── /skills ──────────── (existente, versión pública)
+│   ├── /para-oficinas ──── P-35 Landing Oficina de Empleo
+│   ├── /mi-futuro-laboral  P-36 Landing Mi Futuro Laboral
+│   ├── /metodologia ────── P-37 Metodología MOL
+│   ├── /terminos ────────── P-38 Términos de Uso
+│   └── /politica-datos ──── P-39 Política de Datos
 │
 ├── REGISTRADO (auth, sin acceso a tablero)
 │   ├── /contenido ──────────── P-26 Informes y Notas (contenido completo)
@@ -125,6 +130,11 @@ MOL Platform
 | P-03 | `/informes` | U-VISITANTE | Por crear | [publicas.md#p-03](./03_WIREFRAMES/publicas.md#p-03-informes) |
 | P-04 | `/login` | U-VISITANTE | ✅ Existe | [publicas.md#p-04](./03_WIREFRAMES/publicas.md#p-04-login) |
 | P-05 | `/registro` | U-VISITANTE | Por crear | [publicas.md#p-05](./03_WIREFRAMES/publicas.md#p-05-registro) |
+| P-35 | `/para-oficinas` | U-VISITANTE | ✅ Funcional (2026-03-04) | Landing hub oficina empleo |
+| P-36 | `/mi-futuro-laboral` | U-VISITANTE | ✅ Funcional (2026-03-04) | Landing exploración laboral |
+| P-37 | `/metodologia` | U-VISITANTE | ✅ Funcional (2026-03-04) | Contenido estático |
+| P-38 | `/terminos` | U-VISITANTE | ✅ Placeholder (2026-03-04) | Pendiente contenido legal |
+| P-39 | `/politica-datos` | U-VISITANTE | ✅ Placeholder (2026-03-04) | Pendiente contenido legal |
 
 ### Contenido (Registrados)
 
@@ -205,14 +215,14 @@ MOL Platform
 
 | Categoría | Total | Existentes | Por crear |
 |-----------|-------|------------|-----------|
-| Públicas | 5 | 1 | 4 |
+| Públicas | 10 | 6 | 4 |
 | Contenido | 3 | 1 (placeholder) | 2 |
 | Checkout | 3 | 0 | 3 |
 | Tablero | 5 | 2 | 3 |
 | Oficina Empleo | 3 | 3 (wireframes) | 0 (funcionalidad pendiente) |
 | Cuenta | 3 | 0 | 3 |
 | Admin | 13 | 10 | 3 |
-| **TOTAL** | **35** | **17** | **18** |
+| **TOTAL** | **40** | **22** | **18** |
 
 ---
 
@@ -232,7 +242,7 @@ MOL Platform
 ```typescript
 // middleware.ts (propuesto v2.0)
 
-const PUBLIC_ROUTES = ['/', '/precios', '/informes', '/login', '/registro', '/skills'];
+const PUBLIC_ROUTES = ['/', '/precios', '/informes', '/login', '/registro', '/skills', '/para-oficinas', '/mi-futuro-laboral', '/metodologia', '/terminos', '/politica-datos'];
 
 const REGISTERED_ROUTES = ['/contenido', '/solicitar-acceso', '/cuenta'];
 

--- a/docs/plan/09_ROADMAP.md
+++ b/docs/plan/09_ROADMAP.md
@@ -149,6 +149,12 @@ Seguridad       Escalabilidad    Valor Datos      Features        Diferenciació
 | - | Oficina de Empleo wireframes | MEDIO | /oficina-empleo/* | ✅ Wireframes (2026-03-03) |
 | - | GlobalNav plan-aware | ALTO | GlobalNav.tsx | ✅ Completado (2026-03-03) |
 | - | Home page 4-state CTAs | ALTO | /home | ✅ Completado (2026-03-03) |
+| - | Landing Oficina de Empleo (pública) | MEDIO | P-35 /para-oficinas | ✅ Completado (2026-03-04) |
+| - | Landing Mi Futuro Laboral (pública) | MEDIO | P-36 /mi-futuro-laboral | ✅ Completado (2026-03-04) |
+| - | Metodología (pública) | MEDIO | P-37 /metodologia | ✅ Completado (2026-03-04) |
+| - | Términos de uso (placeholder) | BAJO | P-38 /terminos | ✅ Completado (2026-03-04) |
+| - | Política de datos (placeholder) | BAJO | P-39 /politica-datos | ✅ Completado (2026-03-04) |
+| - | Footer links → páginas reales | MEDIO | app/page.tsx | ✅ Completado (2026-03-04) |
 
 > **Sprint 13 (2026-03-03):** Implementado sistema completo de acceso gated: solicitar-acceso → admin aprueba → trial 7 días se activa automáticamente. Middleware protege /dashboard (requiere admin/suscriptor/trial activo). GlobalNav muestra items según rol+plan. Oficina de empleo con wireframes estáticos. Contenido como placeholder. Migration SQL 017 + RLS en solicitudes_acceso.
 

--- a/fase3_dashboard/mol-dashboard/app/metodologia/page.tsx
+++ b/fase3_dashboard/mol-dashboard/app/metodologia/page.tsx
@@ -1,0 +1,82 @@
+import Link from "next/link";
+import { Database, Brain, Target, GitMerge } from "lucide-react";
+
+const sections = [
+  {
+    icon: Database,
+    title: "Fuentes de datos",
+    content:
+      "El MOL recopila ofertas laborales de los principales portales de empleo de Argentina mediante procesos automatizados de scraping. Las ofertas se actualizan diariamente y se procesan para extraer informacion estructurada.",
+  },
+  {
+    icon: Brain,
+    title: "Procesamiento NLP",
+    content:
+      "Cada oferta es analizada mediante modelos de procesamiento de lenguaje natural (NLP) que extraen informacion clave: titulo limpio, ubicacion, modalidad, seniority, area funcional, tareas, requisitos de experiencia y competencias requeridas.",
+  },
+  {
+    icon: Target,
+    title: "Clasificacion ESCO / ISCO",
+    content:
+      "Las ofertas se clasifican segun la taxonomia europea ESCO (European Skills, Competences, Qualifications and Occupations) y su codigo ISCO asociado. El sistema utiliza un enfoque hibrido: reglas de negocio para casos frecuentes y matching semantico con embeddings para el resto.",
+  },
+  {
+    icon: GitMerge,
+    title: "Matching y validacion",
+    content:
+      "El proceso de matching combina multiples senales: skills extraidas, titulo del puesto, sector economico y area funcional. Cada clasificacion pasa por un sistema de validacion automatica que detecta inconsistencias, y las ofertas con errores criticos son revisadas manualmente antes de incluirse en el dashboard.",
+  },
+];
+
+export const metadata = {
+  title: "Metodologia | MOL",
+  description:
+    "Como funciona el Monitor de Ofertas Laborales: fuentes de datos, procesamiento NLP, clasificacion ESCO y validacion.",
+};
+
+export default function MetodologiaPage() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-16">
+      <span className="inline-block bg-gray-100 text-gray-600 text-[10px] font-bold px-2.5 py-0.5 rounded-full uppercase tracking-wider mb-4">
+        Metodologia
+      </span>
+      <h1 className="text-3xl font-bold text-gray-900 mb-2">
+        Como funciona el MOL
+      </h1>
+      <p className="text-gray-500 mb-10 max-w-2xl">
+        El Monitor de Ofertas Laborales procesa miles de ofertas de empleo para
+        generar indicadores confiables del mercado laboral argentino.
+      </p>
+
+      <div className="space-y-8">
+        {sections.map((section, i) => (
+          <div key={section.title} className="flex gap-4">
+            <div className="shrink-0">
+              <div className="w-10 h-10 bg-gray-100 rounded-lg flex items-center justify-center">
+                <section.icon className="w-5 h-5 text-gray-600" />
+              </div>
+            </div>
+            <div>
+              <h2 className="font-semibold text-gray-900 mb-1">
+                <span className="text-gray-400 mr-2">{i + 1}.</span>
+                {section.title}
+              </h2>
+              <p className="text-sm text-gray-500 leading-relaxed">
+                {section.content}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-12 pt-8 border-t border-gray-200 text-center">
+        <Link
+          href="/"
+          className="text-sm text-gray-400 hover:text-gray-600 transition-colors"
+        >
+          Volver al inicio
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/fase3_dashboard/mol-dashboard/app/mi-futuro-laboral/page.tsx
+++ b/fase3_dashboard/mol-dashboard/app/mi-futuro-laboral/page.tsx
@@ -1,0 +1,92 @@
+import Link from "next/link";
+import { Search, Lightbulb, ArrowLeftRight, ArrowRight } from "lucide-react";
+
+const cards = [
+  {
+    title: "Explora ocupaciones",
+    description:
+      "Descubri las ocupaciones mas demandadas del mercado laboral argentino, con detalle de competencias y requisitos.",
+    icon: Search,
+    tab: "ocupaciones",
+  },
+  {
+    title: "Descubri tus competencias",
+    description:
+      "Recorre la taxonomia ESCO de competencias y encontra cuales se alinean con tu perfil profesional.",
+    icon: Lightbulb,
+    tab: "skills",
+  },
+  {
+    title: "Compara opciones",
+    description:
+      "Analiza distintas ocupaciones lado a lado para entender las diferencias en competencias y oportunidades.",
+    icon: ArrowLeftRight,
+    tab: "comparar",
+  },
+];
+
+export const metadata = {
+  title: "Mi Futuro Laboral | MOL",
+  description:
+    "Explora ocupaciones, descubri competencias y compara opciones para tu carrera profesional.",
+};
+
+export default function MiFuturoLaboralPage() {
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-16">
+      <span className="inline-block bg-blue-100 text-blue-700 text-[10px] font-bold px-2.5 py-0.5 rounded-full uppercase tracking-wider mb-4">
+        Exploracion Laboral
+      </span>
+      <h1 className="text-3xl font-bold text-gray-900 mb-2">
+        Mi Futuro Laboral
+      </h1>
+      <p className="text-gray-500 mb-10 max-w-2xl">
+        Herramientas para explorar el mercado laboral, descubrir ocupaciones,
+        entender que competencias se demandan y planificar tu desarrollo
+        profesional.
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-12">
+        {cards.map((card) => (
+          <Link
+            key={card.tab}
+            href={`/skills?tab=${card.tab}`}
+            className="group relative bg-white rounded-2xl border-2 border-dashed border-gray-300 p-6 hover:border-blue-400 hover:shadow-lg transition-all"
+          >
+            <span className="absolute top-3 right-3 bg-blue-100 text-blue-700 text-[10px] font-bold px-2 py-0.5 rounded-full uppercase tracking-wider">
+              Disponible
+            </span>
+            <div className="w-10 h-10 bg-blue-50 rounded-lg flex items-center justify-center mb-4">
+              <card.icon className="w-5 h-5 text-blue-600" />
+            </div>
+            <h3 className="font-semibold text-gray-900 mb-1 text-sm group-hover:text-blue-700 transition-colors">
+              {card.title}
+            </h3>
+            <p className="text-xs text-gray-500 leading-relaxed">
+              {card.description}
+            </p>
+          </Link>
+        ))}
+      </div>
+
+      <div className="text-center">
+        <Link
+          href="/skills"
+          className="inline-flex items-center gap-2 bg-blue-600 text-white text-sm font-medium px-5 py-2.5 rounded-lg hover:bg-blue-700 transition-colors"
+        >
+          Explorar Skills
+          <ArrowRight className="w-4 h-4" />
+        </Link>
+      </div>
+
+      <div className="mt-8 text-center">
+        <Link
+          href="/"
+          className="text-sm text-gray-400 hover:text-gray-600 transition-colors"
+        >
+          Volver al inicio
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/fase3_dashboard/mol-dashboard/app/page.tsx
+++ b/fase3_dashboard/mol-dashboard/app/page.tsx
@@ -637,18 +637,18 @@ function Footer() {
               </h4>
               <ul className="space-y-2">
                 {[
-                  { label: "Taxonomía ESCO", href: "#" },
-                  { label: "Clasificación ISCO", href: "#" },
-                  { label: "Metodología", href: "#" },
+                  { label: "Oficina de Empleo", href: "/para-oficinas" },
+                  { label: "Mi Futuro Laboral", href: "/mi-futuro-laboral" },
+                  { label: "Metodología", href: "/metodologia" },
                 ].map((link) => (
                   <li key={link.label}>
-                    <a
+                    <Link
                       href={link.href}
                       className="text-sm transition-colors"
                       style={{ color: "var(--slate-300)" }}
                     >
                       {link.label}
-                    </a>
+                    </Link>
                   </li>
                 ))}
               </ul>
@@ -702,20 +702,20 @@ function Footer() {
               &copy; 2026 MOL — Monitor de Ofertas Laborales
             </p>
             <div className="flex items-center gap-6">
-              <a
-                href="#"
+              <Link
+                href="/terminos"
                 className="text-sm transition-colors"
                 style={{ color: "var(--slate-300)" }}
               >
                 Términos
-              </a>
-              <a
-                href="#"
+              </Link>
+              <Link
+                href="/politica-datos"
                 className="text-sm transition-colors"
                 style={{ color: "var(--slate-300)" }}
               >
                 Política de datos
-              </a>
+              </Link>
             </div>
           </div>
         </div>

--- a/fase3_dashboard/mol-dashboard/app/para-oficinas/page.tsx
+++ b/fase3_dashboard/mol-dashboard/app/para-oficinas/page.tsx
@@ -1,0 +1,104 @@
+import Link from "next/link";
+import { UserSearch, Briefcase, Target, ArrowRight } from "lucide-react";
+
+const cards = [
+  {
+    title: "Perfil Trabajador",
+    description:
+      "Registra datos, experiencia y competencias de un trabajador para obtener sugerencias personalizadas.",
+    icon: UserSearch,
+    status: "Proximamente" as const,
+  },
+  {
+    title: "Ofertas Coincidentes",
+    description:
+      "Consulta las ofertas laborales mas relevantes para un perfil registrado, ordenadas por compatibilidad.",
+    icon: Briefcase,
+    status: "Proximamente" as const,
+  },
+  {
+    title: "Taxonomia de Skills",
+    description:
+      "Explora la taxonomia ESCO de competencias y ocupaciones utilizada como referencia internacional.",
+    icon: Target,
+    status: "Disponible" as const,
+  },
+];
+
+export const metadata = {
+  title: "Oficina de Empleo | MOL",
+  description:
+    "Herramientas para oficinas de empleo: perfiles de trabajadores, ofertas coincidentes y taxonomia ESCO.",
+};
+
+export default function ParaOficinasPage() {
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-16">
+      <span className="inline-block bg-teal-100 text-teal-700 text-[10px] font-bold px-2.5 py-0.5 rounded-full uppercase tracking-wider mb-4">
+        Para Oficinas de Empleo
+      </span>
+      <h1 className="text-3xl font-bold text-gray-900 mb-2">
+        Oficina de Empleo
+      </h1>
+      <p className="text-gray-500 mb-10 max-w-2xl">
+        Herramientas para que las oficinas de empleo puedan registrar perfiles de
+        trabajadores y encontrar las ofertas laborales mas compatibles con sus
+        competencias y experiencia.
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-12">
+        {cards.map((card) => (
+          <div
+            key={card.title}
+            className="relative bg-white rounded-2xl border-2 border-dashed border-gray-300 p-6"
+          >
+            <span
+              className={`absolute top-3 right-3 text-[10px] font-bold px-2 py-0.5 rounded-full uppercase tracking-wider ${
+                card.status === "Disponible"
+                  ? "bg-teal-100 text-teal-700"
+                  : "bg-blue-100 text-blue-700"
+              }`}
+            >
+              {card.status}
+            </span>
+            <div className="w-10 h-10 bg-teal-50 rounded-lg flex items-center justify-center mb-4">
+              <card.icon className="w-5 h-5 text-teal-600" />
+            </div>
+            <h3 className="font-semibold text-gray-900 mb-1 text-sm">
+              {card.title}
+            </h3>
+            <p className="text-xs text-gray-500 leading-relaxed">
+              {card.description}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <div className="bg-teal-50 rounded-2xl p-6 text-center">
+        <p className="text-sm text-gray-600 mb-4">
+          Para acceder a estas herramientas necesitas una cuenta con rol{" "}
+          <span className="font-semibold text-teal-700">
+            Oficina de Empleo
+          </span>
+          .
+        </p>
+        <Link
+          href="/oficina-empleo"
+          className="inline-flex items-center gap-2 bg-teal-600 text-white text-sm font-medium px-5 py-2.5 rounded-lg hover:bg-teal-700 transition-colors"
+        >
+          Acceder
+          <ArrowRight className="w-4 h-4" />
+        </Link>
+      </div>
+
+      <div className="mt-8 text-center">
+        <Link
+          href="/"
+          className="text-sm text-gray-400 hover:text-gray-600 transition-colors"
+        >
+          Volver al inicio
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/fase3_dashboard/mol-dashboard/app/politica-datos/page.tsx
+++ b/fase3_dashboard/mol-dashboard/app/politica-datos/page.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+import { Shield } from "lucide-react";
+
+export const metadata = {
+  title: "Politica de Datos | MOL",
+  description:
+    "Politica de proteccion de datos personales del Monitor de Ofertas Laborales.",
+};
+
+export default function PoliticaDatosPage() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-16">
+      <div className="w-12 h-12 bg-gray-100 rounded-xl flex items-center justify-center mb-6">
+        <Shield className="w-6 h-6 text-gray-500" />
+      </div>
+      <h1 className="text-2xl font-bold text-gray-900 mb-2">
+        Politica de Datos
+      </h1>
+      <span className="inline-block bg-amber-100 text-amber-700 text-[10px] font-bold px-2.5 py-0.5 rounded-full uppercase tracking-wider mb-6">
+        En elaboracion
+      </span>
+      <div className="prose prose-gray prose-sm max-w-none">
+        <p className="text-gray-500">
+          La politica de proteccion de datos personales del Monitor de Ofertas
+          Laborales (MOL) esta siendo elaborada. Este documento detallara como
+          se recopilan, almacenan, procesan y protegen los datos personales de
+          los usuarios.
+        </p>
+        <p className="text-gray-500">
+          El MOL procesa datos publicos de ofertas laborales publicadas en
+          portales de empleo. Los datos personales de los usuarios registrados
+          (email, nombre, preferencias) se gestionan a traves de Supabase con
+          autenticacion segura y control de acceso basado en roles.
+        </p>
+        <p className="text-gray-500">
+          Toda la informacion se maneja conforme a la Ley 25.326 de Proteccion
+          de Datos Personales de la Republica Argentina.
+        </p>
+      </div>
+
+      <div className="mt-12 pt-8 border-t border-gray-200 text-center">
+        <Link
+          href="/"
+          className="text-sm text-gray-400 hover:text-gray-600 transition-colors"
+        >
+          Volver al inicio
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/fase3_dashboard/mol-dashboard/app/terminos/page.tsx
+++ b/fase3_dashboard/mol-dashboard/app/terminos/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import { FileText } from "lucide-react";
+
+export const metadata = {
+  title: "Terminos de Uso | MOL",
+  description: "Terminos y condiciones de uso del Monitor de Ofertas Laborales.",
+};
+
+export default function TerminosPage() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-16">
+      <div className="w-12 h-12 bg-gray-100 rounded-xl flex items-center justify-center mb-6">
+        <FileText className="w-6 h-6 text-gray-500" />
+      </div>
+      <h1 className="text-2xl font-bold text-gray-900 mb-2">
+        Terminos de Uso
+      </h1>
+      <span className="inline-block bg-amber-100 text-amber-700 text-[10px] font-bold px-2.5 py-0.5 rounded-full uppercase tracking-wider mb-6">
+        En elaboracion
+      </span>
+      <div className="prose prose-gray prose-sm max-w-none">
+        <p className="text-gray-500">
+          Los terminos y condiciones de uso del Monitor de Ofertas Laborales
+          (MOL) estan siendo elaborados. Este documento detallara las
+          condiciones de acceso, uso de datos y responsabilidades de los
+          usuarios de la plataforma.
+        </p>
+        <p className="text-gray-500">
+          El MOL es un proyecto del Observatorio de Empleo y Dinamica
+          Empresarial (OEDE) del Ministerio de Trabajo, Empleo y Seguridad
+          Social de la Republica Argentina.
+        </p>
+      </div>
+
+      <div className="mt-12 pt-8 border-t border-gray-200 text-center">
+        <Link
+          href="/"
+          className="text-sm text-gray-400 hover:text-gray-600 transition-colors"
+        >
+          Volver al inicio
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/fase3_dashboard/mol-dashboard/components/navigation/GlobalNav.tsx
+++ b/fase3_dashboard/mol-dashboard/components/navigation/GlobalNav.tsx
@@ -85,6 +85,13 @@ const NAV_ITEMS: NavItem[] = [
     matchMode: "startsWith",
   },
   {
+    label: "Mi Futuro Laboral",
+    href: "/mi-futuro-laboral",
+    icon: Target,
+    roles: "*",
+    matchMode: "startsWith",
+  },
+  {
     label: "Informes",
     href: "/informes",
     icon: FileText,

--- a/fase3_dashboard/mol-dashboard/lib/auth-utils.ts
+++ b/fase3_dashboard/mol-dashboard/lib/auth-utils.ts
@@ -15,6 +15,11 @@ export const ALLOWED_REDIRECT_PATHS = [
   '/solicitar-acceso',
   '/contenido',
   '/oficina-empleo',
+  '/para-oficinas',
+  '/mi-futuro-laboral',
+  '/metodologia',
+  '/terminos',
+  '/politica-datos',
 ]
 
 /**

--- a/fase3_dashboard/mol-dashboard/lib/supabase/middleware.ts
+++ b/fase3_dashboard/mol-dashboard/lib/supabase/middleware.ts
@@ -34,7 +34,7 @@ export async function updateSession(request: NextRequest) {
   } = await supabase.auth.getUser();
 
   // Rutas públicas que no requieren autenticación
-  const publicPrefixes = ["/login", "/auth/callback", "/informes", "/precios", "/registro", "/checkout", "/skills"];
+  const publicPrefixes = ["/login", "/auth/callback", "/informes", "/precios", "/registro", "/checkout", "/skills", "/para-oficinas", "/mi-futuro-laboral", "/metodologia", "/terminos", "/politica-datos"];
   const publicExact = ["/"];
   const isPublicRoute =
     publicExact.includes(request.nextUrl.pathname) ||


### PR DESCRIPTION
## Summary

- Replace 5 dead footer links (`href="#"`) with real public pages: `/para-oficinas`, `/mi-futuro-laboral`, `/metodologia`, `/terminos`, `/politica-datos`
- Add "Mi Futuro Laboral" to GlobalNav (visible for all roles)
- Update middleware + auth-utils with the 5 new public routes
- Update plan docs: P-35 to P-39 in architecture, tasks marked done in roadmap

## Test plan

- [ ] Visit each of the 5 new URLs without auth — should render without redirect
- [ ] Footer links on landing page navigate to the correct pages
- [ ] "Mi Futuro Laboral" visible in GlobalNav for all users
- [ ] CTA on `/para-oficinas` → `/oficina-empleo` (redirects to login if not authenticated)
- [ ] CTA on `/mi-futuro-laboral` → `/skills`
- [ ] `npx next build` passes (already verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)