### PR TITLE
docs(specs): adendas transferencia harness 2026-06-11 (S1.B.3 y S1.B.4)

### DIFF
--- a/docs/specs/SPEC_S1B3_MATCHING.md
+++ b/docs/specs/SPEC_S1B3_MATCHING.md
@@ -283,3 +283,19 @@ El norte fundante de toda la fase (frase de Gerardo: "todo este quilombo nace po
 ---
 
 > *Spec S1.B.3 — Matching: capas 5.1 (Gerardo + Cyn), 5.2, 5.3 y 5.4 cerradas. Las 10 deudas observadas se vuelcan al master S1.C cuando esté listo. Los 7 principios son input del diseño objetivo. La deuda D-10 (patrón sistémico) suma la tercera aparición consecutiva del patrón transversal. Acción pendiente que requiere conexión viva: recuperar el Gold Set ampliado desde Supabase (218 validaciones humanas, ventana 2026-03..05).*
+
+---
+
+## Adenda 2026-06-11 — Transferencia del harness (sandbox de escenarios)
+
+> Fuente: nota de transferencia de la conversación paralela del harness (índice de investigaciones mayo-junio, sandbox DuckDB MOL_escenarios, documento "Respuestas a Diego Schleser · v2" del 20-may). Registra evidencia sin priorizar; todo lo accionable converge en S1.C.
+
+### A-1 — La acción pendiente de D-03 queda RESUELTA: el Gold Set ampliado está ubicado
+
+El Gold Set ampliado es la **tabla `gold_set` de Supabase**, poblada por `scripts/ingest_gold_set.py` en el commit `9890779e` (20-may, "Paso D"): 49 → **112 casos**. Composición con prioridad y deduplicación: 30 casos del Excel B2 de Cyn (SPEC W, 2026-05-08) + 9 de `ofertas_dashboard.validacion_humana` + 24-25 del bucket local `ofertas_esco_matching.validado_por` (discrepancia conocida: el docstring dice 24, la BD entrega 25). El índice del harness lo midió en 113 activos a fin de mayo — lo que explica el `test_m10_gold_set.py` que espera 49 y encuentra 113. Recuperable vía `scripts/sync_gold_set.py`.
+
+**Dato crítico adicional**: la precisión sobre los 112/113 **nunca se midió**. El 81,63% que circula es la marca humana estática de diciembre (campo `esco_ok`) que no se recomputa contra el output actual del matcher — no detecta regresiones. El gold set encontrado tampoco está cumpliendo función de regresión.
+
+**Verificación pendiente (ventana de conexión viva)**: `SELECT * FROM gold_set WHERE titulo ILIKE '%sommelier%' OR titulo ILIKE '%carnicer%'` — si los trazadores de Cyn aparecen, confirmación definitiva.
+
+Esto actualiza D-02 (las "≥5 nociones de gold set" tienen ahora su mapa completo) y resuelve la ubicación que D-03 dejaba pendiente. La consolidación sigue siendo trabajo de S1.C.

--- a/docs/specs/SPEC_S1B4_SKILLS.md
+++ b/docs/specs/SPEC_S1B4_SKILLS.md
@@ -319,3 +319,29 @@ Un flag dormido desde su creación no es opcionalidad, es deuda con apariencia d
 ---
 
 > *Spec S1.B.4 — Skills: capas 5.1 (Gerardo + Cyn + modelo conceptual), 5.2, 5.3 y 5.4 cerradas. Las 12 deudas observadas se vuelcan al master S1.C. Los 7 principios son input del diseño objetivo. D-12 confirma el patrón transversal por cuarta vez consecutiva, sumando la variante "construido y nunca encendido". Hallazgo central del spec: el sistema está más construido y menos conectado de lo que el propio modelo conceptual suponía — la categoría CONECTAR crece, la categoría CREAR se achica.*
+
+---
+
+## Adenda 2026-06-11 — Transferencia del harness (sandbox de escenarios)
+
+> Fuente: nota de transferencia de la conversación paralela del harness (verificación FACTIBILIDAD_S0 del 2026-06-10 read-only contra código y BD local; clasificador observacional del sandbox MOL_escenarios sobre las 1.569.227 filas de `ofertas_esco_skills_detalle`). Registra evidencia sin priorizar; todo lo accionable converge en S1.C.
+
+### A-2 — Drift de embeddings: 8.381 URIs huérfanas (amplía D-06)
+
+8.381 filas de `ofertas_esco_skills_detalle` con `skill_tipo_fuente='semantico'` tienen una `esco_skill_uri` que **no existe en `esco_skills`**. Hipótesis que conecta con el manifest relevado en 5.2.2: el `.npy` se generó desde `source_table = esco_skills_enriched` (14.257 filas, SPEC E) mientras el lookup de runtime va contra `esco_skills` — si las dos tablas divergieron, los embeddings y el catálogo de runtime son corpus distintos. D-06 deja de ser solo "falta metadata de release" y suma "posible divergencia de corpus". Verificación pendiente (conexión/consulta): conteo de URIs de `esco_skills_enriched` ausentes en `esco_skills`.
+
+### A-3 — Hay una segunda fosa, anónima (matiza D-03 y el Principio 2)
+
+`_filter_llm_skills` (`skills_implicit_extractor.py`, ~líneas 813 y 821) descarta skills del LLM **sin escribir al cementerio** — el rechazo no deja rastro en ninguna tabla. El cementerio captura los descartes del gate de similitud; los del filtro/salvavidas se pierden sin registro (estimación: ~25% de lo extraído por el LLM). Implicancia para S1.C: "drenar el cementerio" no recupera todo lo perdido; cualquier diseño de captura de emergentes necesita instrumentar también ese punto.
+
+### A-4 — Cuantificación poblacional de D-04 (sustento empírico del Principio 6)
+
+Medido por el sandbox sobre las 1.569.227 filas: **90%+ de los pares (ocupación, skill) declarados están fuera del canon `esco_associations` de su ocupación** — la divergencia AR↔EU es la condición normal del corpus, no la excepción. Núcleo con evidencia fuerte: **3.292 pares únicos con respaldo multi-empresa** (≥3 empresas) que el grafo europeo no conecta; con criterio estricto (v1.1), 13.252 filas elegibles. La otra cara: **972 URIs "comodín"** (asignadas a ≥100 ocupaciones; 196 cubren el 50% de las filas afectadas) — coincide con las "526 skills magnéticas" del Informe de mayo, medido sobre más datos. De los 3.292 pares, solo **43 coinciden con la curaduría de `esco_argentino`** (~1,3% de cobertura); ~870 caen dentro de las 44 ocupaciones ya curadas — candidatos inmediatos a validación humana si S1.C lo prioriza. Reportes completos en `MOL_escenarios/data_out/`.
+
+### A-5 — Tercera columna zombi: `match_method` colapsado (amplía D-01)
+
+`match_ofertas_v3.py:~1645` hardcodea `match_method='implicit_bge_m3'` al persistir, perdiendo el método real. Cuadro completo de la tabla: dos columnas de procedencia muertas (`origen_tipo`, `match_method`) y una viva (`skill_tipo_fuente`). El riesgo de que un consumidor futuro lea la columna equivocada es doble.
+
+### A-6 — Genealogía del cementerio (amplía D-03 y D-12)
+
+(1) El cementerio tiene spec propio: `docs/plan/SPEC_M06_SKILLS_FAILURES_V2.md` — implementación deliberada (M-06), no acumulación accidental. (2) **M-13 figura "Completado 2026-03-30"** en el roadmap, prometiendo exactamente el "registro de skills sin URI con identidad propia" que no existe según ambas verificaciones independientes — variante nueva del patrón D-15: **"declarado completado sin estarlo"**. (3) Los 12 tests de M-06 en rojo (corrida 2026-06-03) fallan con `AttributeError: 'SkillsImplicitExtractor' object has no attribute 'filtrar_por_trust'`. **Verificación T6.3 (lectura de `tests/test_m06_skills_failures.py` y `tests/test_m06_regression.py`) — veredicto distinto al esperado**: ninguno de los dos archivos invoca `filtrar_por_trust`, ni como método ni como parámetro. El `AttributeError` no proviene de una API inexistente, sino de **drift de fixture**: ambas fixtures construyen el extractor con `SkillsImplicitExtractor.__new__(...)` (saltando `__init__`) y setean a mano una lista fija de atributos que **omite `self.filtrar_por_trust`**. Ese atributo es un parámetro real del constructor (`skills_implicit_extractor.py:107`, default False, asignado en `:132`) que el path de extracción lee internamente (`:936` y `:941`); como la instancia de test nunca pasó por `__init__`, la lectura revienta. Es decir: el parámetro `filtrar_por_trust` se agregó al `__init__` **después** de escritas las fixtures de M-06, y nunca se actualizaron — confirma la variante "construido y nunca encendido" de S1.B.4 (el parámetro vive con default False, jamás activado) y suma una instancia limpia de D-12: feature agregado a la clase sin sincronizar su harness de tests.

--- a/exports/cyn_backlog/PR_body_adendas_harness.md
+++ b/exports/cyn_backlog/PR_body_adendas_harness.md
@@ -1,0 +1,20 @@
+# docs(specs): adendas de transferencia harness en S1.B.3 y S1.B.4
+
+## Qué registra
+
+Evidencia transferida desde la conversación paralela del harness (sandbox MOL_escenarios, índice de investigaciones, FACTIBILIDAD_S0), registrada como adendas con fuente en los dos specs ya cerrados que toca. Según protocolo del master v0.2: sin priorización — todo converge en S1.C.
+
+- **S1.B.3 / A-1**: el Gold Set ampliado UBICADO (tabla `gold_set` de Supabase, commit 9890779e, 112-113 casos, composición exacta). Resuelve la acción pendiente de D-03. Dato crítico: la precisión sobre el ampliado nunca se midió.
+- **S1.B.4 / A-2**: 8.381 URIs huérfanas — posible divergencia entre el corpus de embeddings (enriched) y el catálogo de runtime (esco_skills).
+- **S1.B.4 / A-3**: segunda fosa anónima — `_filter_llm_skills` descarta sin escribir al cementerio (~25% de lo extraído).
+- **S1.B.4 / A-4**: cuantificación poblacional de la divergencia AR↔EU (90%+ fuera del canon; 3.292 pares multi-empresa; 972 URIs comodín; curaduría cubre ~1,3%).
+- **S1.B.4 / A-5**: tercera columna zombi (`match_method` hardcodeado).
+- **S1.B.4 / A-6**: genealogía del cementerio — M-06 tiene spec, M-13 "completado" sin estarlo (variante nueva de D-15), y el veredicto de los tests en rojo.
+
+## Verificación incluida
+
+T6.3 verificada por lectura de los dos archivos de tests de M-06. **Veredicto distinto al esperado**: ninguno de los dos archivos invoca `filtrar_por_trust` (ni método ni parámetro). El `AttributeError` no viene de una API inexistente sino de **drift de fixture** — las fixtures usan `__new__` (saltan `__init__`) y omiten `self.filtrar_por_trust`, atributo que el path de extracción lee (`:936`/`:941`) y que es un parámetro real del constructor (`:107`, default False) agregado después de escritas las fixtures. El texto de A-6 quedó ajustado a este hallazgo.
+
+## DEPLOY_RULES
+
+Documentos de relevamiento. Sin impacto en producción.


### PR DESCRIPTION
# docs(specs): adendas de transferencia harness en S1.B.3 y S1.B.4

## Qué registra

Evidencia transferida desde la conversación paralela del harness (sandbox MOL_escenarios, índice de investigaciones, FACTIBILIDAD_S0), registrada como adendas con fuente en los dos specs ya cerrados que toca. Según protocolo del master v0.2: sin priorización — todo converge en S1.C.

- **S1.B.3 / A-1**: el Gold Set ampliado UBICADO (tabla `gold_set` de Supabase, commit 9890779e, 112-113 casos, composición exacta). Resuelve la acción pendiente de D-03. Dato crítico: la precisión sobre el ampliado nunca se midió.
- **S1.B.4 / A-2**: 8.381 URIs huérfanas — posible divergencia entre el corpus de embeddings (enriched) y el catálogo de runtime (esco_skills).
- **S1.B.4 / A-3**: segunda fosa anónima — `_filter_llm_skills` descarta sin escribir al cementerio (~25% de lo extraído).
- **S1.B.4 / A-4**: cuantificación poblacional de la divergencia AR↔EU (90%+ fuera del canon; 3.292 pares multi-empresa; 972 URIs comodín; curaduría cubre ~1,3%).
- **S1.B.4 / A-5**: tercera columna zombi (`match_method` hardcodeado).
- **S1.B.4 / A-6**: genealogía del cementerio — M-06 tiene spec, M-13 "completado" sin estarlo (variante nueva de D-15), y el veredicto de los tests en rojo.

## Verificación incluida

T6.3 verificada por lectura de los dos archivos de tests de M-06. **Veredicto distinto al esperado**: ninguno de los dos archivos invoca `filtrar_por_trust` (ni método ni parámetro). El `AttributeError` no viene de una API inexistente sino de **drift de fixture** — las fixtures usan `__new__` (saltan `__init__`) y omiten `self.filtrar_por_trust`, atributo que el path de extracción lee (`:936`/`:941`) y que es un parámetro real del constructor (`:107`, default False) agregado después de escritas las fixtures. El texto de A-6 quedó ajustado a este hallazgo.

## DEPLOY_RULES

Documentos de relevamiento. Sin impacto en producción.
