### PR TITLE
feat(spec-s1c-f03): Observabilidad del Eje 1 — acta de corrida + alertas (log + UI)

### DIFF
--- a/database/migrations/025_pipeline_observabilidad.sql
+++ b/database/migrations/025_pipeline_observabilidad.sql
@@ -1,0 +1,43 @@
+-- 025_pipeline_observabilidad.sql
+-- SPEC S1C-F0.3 — Observabilidad del Eje 1: acta de corrida + alertas
+-- Fecha: 2026-06-16
+--
+-- ADITIVA: no toca pipeline_runs (matching-scoped) ni la tabla legacy 'alertas'.
+-- Crea dos tablas nuevas locales:
+--   pipeline_run_actas  -> acta a nivel-corrida (fuente de verdad), escrita por run_validated_pipeline.py
+--   pipeline_alertas    -> registro estructurado de fallos del pipeline
+
+-- ── Acta de corrida ──────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS pipeline_run_actas (
+    acta_id            TEXT PRIMARY KEY,   -- acta_YYYYMMDD_HHMMSS
+    started_at         TEXT NOT NULL,      -- inicio (al entrar a run_full_pipeline)
+    finished_at        TEXT,               -- fin; NULL mientras corre
+    invocador          TEXT,               -- 'poller' | 'terminal'
+    args               TEXT,               -- flags de invocacion (limit/ids/skip-*)
+    alcance_entrada    INTEGER,            -- ofertas que entraron
+    alcance_procesado  INTEGER,            -- ofertas efectivamente procesadas
+    resultado          TEXT,               -- 'ok' | 'fallida' | 'incompleta' | NULL (en curso)
+    fallos             TEXT,               -- JSON array de alertas-clave de esta corrida
+    matching_run_id    TEXT,               -- FK logica a pipeline_runs.run_id (si llego a matching)
+    pid                INTEGER,            -- PID del proceso que abrio el acta
+    host               TEXT                -- hostname (PID solo comparable dentro del mismo host)
+);
+
+-- Buscar actas abiertas (barrido de huerfanas) y ordenar por recencia
+CREATE INDEX IF NOT EXISTS idx_actas_abiertas   ON pipeline_run_actas(finished_at);
+CREATE INDEX IF NOT EXISTS idx_actas_started     ON pipeline_run_actas(started_at);
+
+-- ── Registro de alertas ──────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS pipeline_alertas (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp   TEXT NOT NULL,
+    severidad   TEXT NOT NULL,             -- 'info' | 'warning' | 'error' | 'critico'
+    tipo        TEXT NOT NULL,             -- ollama_down | nlp_fallo | paso_bloqueante
+                                           --   | sync_no_corrio | corrida_incompleta | export_fallo
+    mensaje     TEXT NOT NULL,             -- texto claro y accionable
+    acta_id     TEXT,                      -- corrida asociada (NULL si no aplica)
+    contexto    TEXT                       -- JSON con detalle
+);
+
+CREATE INDEX IF NOT EXISTS idx_alertas_timestamp ON pipeline_alertas(timestamp);
+CREATE INDEX IF NOT EXISTS idx_alertas_acta      ON pipeline_alertas(acta_id);

--- a/docs/specs/SPEC_S1C_F03_OBSERVABILIDAD.md
+++ b/docs/specs/SPEC_S1C_F03_OBSERVABILIDAD.md
@@ -95,14 +95,29 @@ El acta **por-comando** y el **panel** ya existen (Supabase, solo vía poller). 
 | `args` | TEXT | flags de invocación (limit/ids/skip-*) |
 | `alcance_entrada` | INTEGER | ofertas que entraron a la corrida |
 | `alcance_procesado` | INTEGER | ofertas efectivamente procesadas |
-| `resultado` | TEXT | `ok` \| `fallida` \| `incompleta` |
+| `resultado` | TEXT | `ok` \| `fallida` \| `incompleta` \| (NULL mientras corre) |
 | `fallos` | TEXT | JSON array de alertas-clave de esta corrida |
 | `matching_run_id` | TEXT NULL | FK lógica a `pipeline_runs.run_id` (si llegó a matching) |
+| `pid` | INTEGER | PID del proceso que abrió el acta (para distinguir en curso vs muerta) |
+| `host` | TEXT | hostname donde corrió (PID solo es comparable dentro del mismo host) |
 
 **Estados de `resultado`:**
 - `ok`: la corrida llegó al final sin fallos bloqueantes.
-- `fallida`: terminó por un fallo (bloqueante, exit≠0 controlado).
-- `incompleta`: empezó y no cerró (`finished_at` quedó NULL) — corrida interrumpida/crash. Se deriva: una acta con `finished_at IS NULL` y `started_at` viejo es incompleta. Una corrida nueva marca como `incompleta` cualquier acta huérfana previa al arrancar (barrido de apertura).
+- `fallida`: terminó por un fallo (bloqueante, o exit≠0 controlado).
+- `incompleta`: empezó y no cerró — corrida interrumpida/crash.
+- `NULL`: acta abierta de una corrida **en curso** (todavía no cerró, pero viva).
+
+**Mecanismo de `incompleta` — decisión consciente (el problema y su resolución).**
+Una corrida **en curso** y una **muerta** se ven idénticas con `finished_at IS NULL`: nada las distingue por sí solo. Para resolverlo de forma determinista, sin depender de un timeout frágil:
+
+- **Quién y cuándo hace el barrido:** `run_validated_pipeline.py` ejecuta `barrer_actas_huerfanas()` (de `scripts/observabilidad.py`) **al inicio de cada corrida, antes de crear la nueva acta**. Es el único momento garantizado y suficiente: como el poller ejecuta comandos en serie (single-execution) y las corridas de terminal son manuales, al arrancar una corrida nueva cualquier acta previa abierta pertenece a una corrida que ya no está. El barrido es además invocable on-demand (endpoint/poller) por si se quiere refrescar la UI sin arrancar corrida.
+- **Regla de distinción (en curso vs muerta):** un acta abierta (`finished_at IS NULL`) se marca `incompleta` si, **en su mismo `host`**, se cumple **cualquiera** de:
+  1. su `pid` ya no corresponde a un proceso vivo (`os.kill(pid, 0)` → `ProcessLookupError`), **o**
+  2. su `started_at` supera el timeout máximo de corrida (8 h — el mismo `subprocess timeout` del poller), como respaldo cuando el PID no es confiable (reinicio de máquina que reusa PIDs, u otro host).
+  - **En curso** = abierta + pid vivo + dentro del timeout → se respeta, no se toca.
+  - **Muerta** = abierta + (pid no vivo **o** fuera de timeout) → `incompleta`.
+- **Sesgo elegido:** la regla nunca marca `incompleta` a una corrida viva (un pid vivo dentro de 8 h siempre se respeta; el poller mata a las 8 h, así que ninguna corrida legítima excede ese límite viva). El único residuo es un falso negativo raro (un acta muerta cuyo PID fue reusado por otro proceso vivo dentro de la misma ventana de 8 h queda abierta hasta cumplirse el timeout). Se acepta a conciencia: preferimos no mentir sobre una corrida viva antes que cerrar agresivamente una muerta.
+- **Efecto:** cada acta barrida emite una alerta `corrida_incompleta` (ver 4.2).
 
 ### 4.2 Registro de alertas (local + log)
 **Tabla nueva `pipeline_alertas`** (no reutilizar `alertas` legacy — ver Riesgos):

--- a/docs/specs/SPEC_S1C_F03_OBSERVABILIDAD.md
+++ b/docs/specs/SPEC_S1C_F03_OBSERVABILIDAD.md
@@ -1,0 +1,199 @@
+# SPEC S1C-F0.3 — Observabilidad del Eje 1: acta de corrida + alertas (log + UI)
+
+> **Estado:** Parte 1 (verificación + diseño) — **esperando OK del punto de control antes de implementar.**
+> **Fase:** 0 (cimientos) del master S1.C — Reparación.
+> **Tipo:** primer spec que toca código de producción (los anteriores fueron discovery read-only).
+> **Riesgo:** contenido — agrega registro y visualización, **no cambia la lógica de qué se procesa**.
+> **Fecha:** 2026-06-16. **Branch:** `spec/s1c-f03-observabilidad`.
+
+---
+
+## 1. Propósito
+
+Que la fábrica deje rastro de sí misma: **cada corrida del pipeline debe dejar acta** (inicio, fin, alcance, resultado, fallos), **cada fallo debe registrarse como alerta** estructurada (no solo un print que se pierde), y **un panel en la pantalla de fábrica que ya existe** debe mostrar la última corrida y las alertas recientes sin abrir terminal.
+
+Este spec construye el primer cimiento del **Eje 1** del master ("la fábrica corre sola"): no se puede operar una fábrica que no se observa. **No incluye** el criterio único de elegibilidad (4 mecanismos + 8 estados) — eso es F0.4, de alto riesgo, separado a propósito.
+
+---
+
+## 2. Estado verificado (read-only, 2026-06-16)
+
+Antes de diseñar se verificó contra código y BD local. **El alcance asumido cambia parcialmente: parte del "acta + panel" ya existe.** Detalle:
+
+### 2.1 `pipeline_runs` (sqlite local, 616 filas) — es matching-scoped, no pipeline-scoped
+- **Quién la escribe:** `database/match_ofertas_v3.py` vía `RunTracker.create_run` (`scripts/run_tracking.py:158`). Es decir, la fila nace **dentro del paso de matching**, no al inicio del pipeline.
+- **Qué tiene:** `run_id`, **un solo** `timestamp` (inicio), `source`, versiones NLP/matcher, git branch/commit, `ofertas_count`/`ofertas_ids` (alcance), métricas de matching, `errores_detectados/corregidos/escalados`.
+- **Qué NO tiene:** `finished_at` (fin), columna `resultado`/`estado` ∈ {ok, fallida, incompleta}, lista de fallos. Última fila: 2026-05-16.
+- **Consecuencia (confirma D-03 de S1.B.6):** no hay marca de "corrida incompleta". Y si la corrida **muere en NLP antes de llegar a matching** (caso Ollama caído), **no deja ninguna fila local** → el fallo más importante es hoy invisible localmente.
+
+### 2.2 Puntos de fallo en `scripts/run_validated_pipeline.py`
+| Punto | Línea | Comportamiento hoy |
+|---|---|---|
+| NLP (Ollama, extracción) | 290-297 | `try/except` → imprime `Error en NLP: …` y **continúa silenciosamente** |
+| Paso bloqueante (errores sin resolver) | 711-721 | `sys.exit(1)` controlado, imprime motivo |
+| Sin ofertas pendientes | 732-735 | `sys.exit(0)` |
+| Export Excel | 638-653 | `try/except` → "Warning", continúa |
+| Sync learnings.yaml | 661-666 | `try/except` → "Warning", continúa |
+| Exit por escalamiento | 780-782 | `sys.exit(1)` si hay `patrones_claude` |
+
+`OLLAMA_HOST` lo fija el poller (`env['OLLAMA_HOST']='172.17.0.1'`, poller L257). No hay healthcheck explícito de Ollama antes de NLP.
+
+### 2.3 Logging
+**No hay logger estructurado.** Todo es `safe_print` → stdout. El único que captura el stdout/stderr es el **poller**, que guarda los últimos 5K/2K caracteres en `pipeline_commands.log` (Supabase). Una corrida lanzada **directo por terminal no deja ese rastro**. Existe dir `logs/` (con `.gitkeep`) para logs a archivo.
+
+### 2.4 El poller ya registra un acta **por comando** (en Supabase)
+`scripts/pipeline_command_poller.py` ya escribe, por cada comando que ejecuta, en la tabla Supabase `pipeline_commands`:
+`estado` (pendiente → ejecutando → completado/error), `started_at`, `completed_at`, `duracion_seg`, `log` (stdout+stderr truncado), `error_message`, `resultado` (JSON con exit_code + salida estructurada M-08c). Distingue completado / error / timeout. Cada ciclo además hace `sync_local_status` → tabla `pipeline_local_status` (snapshot de conteos).
+**Limitación:** vive en Supabase y **solo para corridas invocadas vía poller**; no respeta el principio nº7 (residencia local como fuente de verdad), y es por-comando, no por-corrida con resultado normalizado + fallos.
+
+### 2.5 La pantalla de fábrica ya tiene panel + polling
+`app/admin/procesamiento/fabrica/page.tsx`:
+- Sección **"Actividad reciente"**: últimos 8 comandos (estado, duración, `error_message`, procesadas).
+- **Polling cada 5s** sobre `/api/pipeline-commands` (solo si hay `estado==='ejecutando'`).
+- **Toast inline** (`message` ok/error).
+- API routes con **service-role client** (`SUPABASE_SERVICE_ROLE_KEY`).
+- **`pipeline_runs` NO se lee en fábrica** (sí en `/api/processing-metrics` y `/admin/metricas`, contra Supabase `pipeline_runs_history`).
+
+### 2.6 Sync / pollers
+`auto_sync.sh` (cron horario): VPS→local→Supabase, loguea a `/tmp/mol_auto_sync.log`, **sin registro de resultado consultable**. `pipeline_command_poller.py`: ver 2.4.
+
+### 2.7 Tablas locales preexistentes relevantes
+- `alertas` (5 filas, 2025-10, **legacy data-quality** escrita por `dashboard_scraping_v4.py`/`db_manager.py`; schema `timestamp/level/type/message/context`). Reutilizable o a evitar por colisión semántica — ver Riesgos.
+- `batch_runs` (34 filas, vincula lote↔run), `run_ofertas`.
+
+### 2.8 Contradicción con el alcance asumido → **delta real de este spec**
+El acta **por-comando** y el **panel** ya existen (Supabase, solo vía poller). Lo que falta de verdad y respeta residencia local:
+1. **Acta LOCAL a nivel-corrida**, creada al **inicio** del pipeline (no mid-matching), fuente de verdad, independiente de Supabase y del camino de invocación, con `resultado ∈ {ok, fallida, incompleta}` y lista de fallos.
+2. **Registro estructurado de alertas** emitido en los puntos de fallo de 2.2 (hoy se tragan o solo quedan en el blob de stdout de Supabase).
+3. **Panel**: en gran parte ya existe; el delta es mostrar el **acta a nivel-corrida + alertas**, no solo el log crudo del comando.
+
+---
+
+## 3. Reutilización (no reinventar)
+
+| Se reutiliza | De dónde |
+|---|---|
+| Patrón toast + polling 5s | `fabrica/page.tsx` (sección Actividad reciente) |
+| Cliente service-role + `requireAdmin` | API routes `/api/pipeline-*` |
+| Empuje local→Supabase cada ciclo | `pipeline_command_poller.py::sync_local_status` (se le suma acta+alertas) |
+| Tabla `pipeline_runs` local | se mantiene intacta; el acta de corrida vive en tabla nueva que la referencia |
+| Dir `logs/` | destino del log estructurado de alertas |
+
+---
+
+## 4. Entregables (diseño propuesto)
+
+### 4.1 Acta de corrida (local, fuente de verdad)
+**Decisión de diseño:** tabla nueva `pipeline_run_actas` (sqlite local) escrita por `run_validated_pipeline.py`, **sin tocar** lo que `pipeline_runs` ya escribe (no disruptividad). Se crea al **inicio** y se cierra al **fin**.
+
+| Columna | Tipo | Significado |
+|---|---|---|
+| `acta_id` | TEXT PK | `acta_YYYYMMDD_HHMMSS` |
+| `started_at` | TEXT | inicio de la corrida (al entrar a `run_full_pipeline`) |
+| `finished_at` | TEXT NULL | fin; NULL mientras corre |
+| `invocador` | TEXT | `poller` \| `terminal` |
+| `args` | TEXT | flags de invocación (limit/ids/skip-*) |
+| `alcance_entrada` | INTEGER | ofertas que entraron a la corrida |
+| `alcance_procesado` | INTEGER | ofertas efectivamente procesadas |
+| `resultado` | TEXT | `ok` \| `fallida` \| `incompleta` |
+| `fallos` | TEXT | JSON array de alertas-clave de esta corrida |
+| `matching_run_id` | TEXT NULL | FK lógica a `pipeline_runs.run_id` (si llegó a matching) |
+
+**Estados de `resultado`:**
+- `ok`: la corrida llegó al final sin fallos bloqueantes.
+- `fallida`: terminó por un fallo (bloqueante, exit≠0 controlado).
+- `incompleta`: empezó y no cerró (`finished_at` quedó NULL) — corrida interrumpida/crash. Se deriva: una acta con `finished_at IS NULL` y `started_at` viejo es incompleta. Una corrida nueva marca como `incompleta` cualquier acta huérfana previa al arrancar (barrido de apertura).
+
+### 4.2 Registro de alertas (local + log)
+**Tabla nueva `pipeline_alertas`** (no reutilizar `alertas` legacy — ver Riesgos):
+
+| Columna | Tipo | |
+|---|---|---|
+| `id` | INTEGER PK | |
+| `timestamp` | TEXT | |
+| `severidad` | TEXT | `info` \| `warning` \| `error` \| `critico` |
+| `tipo` | TEXT | `ollama_down` \| `nlp_fallo` \| `paso_bloqueante` \| `sync_no_corrio` \| `corrida_incompleta` \| `export_fallo` |
+| `mensaje` | TEXT | texto claro y accionable |
+| `acta_id` | TEXT NULL | corrida asociada |
+| `contexto` | TEXT | JSON con detalle |
+
+**Doble persistencia:** además de la tabla, append a `logs/pipeline_alertas.jsonl` (una alerta por línea, JSON) — log estructurado, fuente local independiente.
+
+**Puntos de emisión** (de 2.2):
+| Punto | severidad | tipo |
+|---|---|---|
+| NLP lanza excepción (L290-297) | `error` | `nlp_fallo` (si la causa es conexión Ollama → `ollama_down`) |
+| Paso bloqueante (L711-721) | `warning` | `paso_bloqueante` |
+| Export Excel falla (L638-653) | `warning` | `export_fallo` |
+| Sync learnings falla (L661-666) | `warning` | `sync_no_corrio` |
+| Acta cerrada como `incompleta` (barrido de apertura) | `error` | `corrida_incompleta` |
+
+El emisor es un helper único (`scripts/observabilidad.py::emitir_alerta(severidad, tipo, mensaje, acta_id, contexto)`) que escribe tabla + jsonl. No cambia ninguna decisión de procesamiento; solo registra.
+
+### 4.3 Panel en `procesamiento/fabrica`
+**Se suma** una sección "Última corrida" + "Alertas recientes" a la pantalla existente (no pantalla nueva), reusando card + toast + polling.
+- **Endpoint nuevo:** `GET /api/pipeline-last-run` (service-role + `requireAdmin`) → `{ ultimaActa, alertas[] }` leyendo de Supabase (espejo subido por el poller).
+- **Camino del dato (residencia nº7):** acta + alertas se escriben **local primero**; `pipeline_command_poller.py::sync_local_status` (ya corre cada ciclo) **sube** la última acta + alertas recientes a Supabase (`pipeline_local_status` extendida o tabla espejo `pipeline_actas_mirror`). La UI lee Supabase como hoy.
+- **Polling:** reusar el de 5s; o un fetch al montar + refresco al terminar un comando (suficiente, sin polling extra agresivo).
+
+**Mockup textual:**
+```
+┌─ Última corrida ──────────────────────────────┐
+│ acta_20260616_1432 · hace 8 min · vía poller   │
+│ ● ok   ·  entraron 100 · procesadas 97         │
+│ matching run_20260616_1433                     │
+├─ Alertas recientes (3) ────────────────────────┤
+│ ⚠ warning · sync_no_corrio · hace 8 min        │
+│   "learnings.yaml no sincronizó: timeout"      │
+│ ✖ error · ollama_down · hace 2 h               │
+│   "NLP abortó: conexión rechazada 172.17.0.1"  │
+└────────────────────────────────────────────────┘
+```
+
+---
+
+## 5. Implementación (SOLO tras OK del punto de control)
+
+Orden incremental, un commit por paso; punto de control intermedio entre paso 2 y 3:
+1. **Migración aditiva**: `pipeline_run_actas` + `pipeline_alertas` (sqlite local) + columnas/tabla espejo en Supabase. No toca `pipeline_runs`.
+2. **Acta en `run_validated_pipeline.py`**: crear al inicio de `run_full_pipeline`, cerrar al fin con `resultado`; barrido de apertura para huérfanas. Sin cambiar lógica de selección/procesamiento.
+   - **Punto de control intermedio**: verificar en una corrida real que el acta se escribe correcta (inicio/fin/resultado/alcance) antes de seguir.
+3. **Alertas**: helper `emitir_alerta` + enganches en los 5 puntos de 4.2.
+4. **Endpoint** `/api/pipeline-last-run` + empuje desde `sync_local_status`.
+5. **Panel** en `fabrica/page.tsx` leyendo datos reales.
+
+---
+
+## 6. Dependencias
+- Lectura BD local sqlite + Supabase service-role (ya configurado en poller y API routes).
+- El empuje a Supabase depende del poller corriendo (ya es el caso en operación). Si el poller no corre, el acta+alertas **igual existen local** (fuente de verdad); solo no se reflejan en UI hasta el próximo ciclo.
+
+---
+
+## 7. Validación (criterios binarios)
+| # | Test | Criterio binario |
+|---|---|---|
+| T1 | Una corrida (o dry-run seguro) escribe un acta con inicio, fin, alcance y resultado | el acta existe y tiene los 4 campos no-NULL |
+| T2 | Una corrida interrumpida queda `incompleta`, distinguible de `ok` | `resultado='incompleta'` tras barrido de apertura |
+| T3 | Un fallo simulado (ej. Ollama no disponible) emite alerta en tabla **y** en `logs/pipeline_alertas.jsonl` | la alerta aparece en ambos, con `tipo=ollama_down` |
+| T4 | El panel muestra la última corrida + alertas recientes con datos reales | el panel renderiza el acta real (no mock) |
+
+Tests Python en `tests/` (acta + alertas) y test de componente en `__tests__/component/` (panel), siguiendo los patrones existentes.
+
+---
+
+## 8. Riesgos
+- **Aditividad estricta:** no tocar columnas/escritura de `pipeline_runs`; tabla de acta separada que la referencia.
+- **No tocar lógica de selección/procesamiento:** los enganches de alerta solo registran; ningún `emitir_alerta` cambia el flujo (el flujo ya hace lo que hace en cada `except`).
+- **Colisión con `alertas` legacy:** se usa tabla nueva `pipeline_alertas` para no contaminar ni romper lectores del `alertas` legacy (dashboards viejos).
+- **Dependencia del poller para la UI:** mitigada porque local es fuente de verdad; la UI es espejo.
+- **Doble fuente (Supabase `pipeline_commands` vs acta local):** se documenta que la acta local es la fuente de verdad a nivel-corrida; `pipeline_commands` queda como registro a nivel-comando del poller (no se elimina ni se duplica su rol).
+
+---
+
+## 9. Criterio de aceptación
+- Acta local a nivel-corrida con `resultado ∈ {ok, fallida, incompleta}` escribiéndose en corridas reales.
+- Alertas emitidas en los 5 puntos de fallo, en tabla + jsonl.
+- Panel en `procesamiento/fabrica` mostrando última corrida + alertas con datos reales.
+- T1-T4 verdes. Sin regresión en lo que `pipeline_runs` / el pipeline ya hacen.
+- (Eje 6 / definición de terminado) consumidor conectado = panel mostrando datos reales.

--- a/docs/specs/SPEC_S1C_F03_OBSERVABILIDAD.md
+++ b/docs/specs/SPEC_S1C_F03_OBSERVABILIDAD.md
@@ -212,3 +212,27 @@ Tests Python en `tests/` (acta + alertas) y test de componente en `__tests__/com
 - Panel en `procesamiento/fabrica` mostrando última corrida + alertas con datos reales.
 - T1-T4 verdes. Sin regresión en lo que `pipeline_runs` / el pipeline ya hacen.
 - (Eje 6 / definición de terminado) consumidor conectado = panel mostrando datos reales.
+
+---
+
+## 10. Estado de implementación (2026-06-16)
+
+Implementado en 5 pasos incrementales (1 commit por paso) sobre `spec/s1c-f03-observabilidad`:
+
+| Paso | Qué | Commit |
+|---|---|---|
+| 1 | Migración 025 (sqlite): `pipeline_run_actas` + `pipeline_alertas` | `692c6f35` |
+| 2 | Acta en `run_validated_pipeline.py` (barrido + abrir/cerrar + resultado) | `3863d6fa` |
+| 3 | `emitir_alerta` (tabla + jsonl) en los 5 puntos de fallo | `3eee50aa` |
+| 4+5 | Migración 066 (Supabase mirror) + poller + endpoint + panel | `e4bf4d1f` |
+
+**Tests verdes:**
+- Python (`tests/test_observabilidad_actas.py`): 11. Cubren T1 (run real escribe acta ok/fallida), T2 (barrido distingue viva/muerta/timeout), T3 (alerta en tabla **y** jsonl por tipo), lector del poller, y que la observabilidad nunca rompe el pipeline.
+- Frontend (`__tests__/component/fabrica-page.test.tsx`): 12 (panel renderiza acta real + alertas). T4.
+
+**Pasos manuales pendientes (de Gerardo — fuera del alcance read-only/no-deploy):**
+1. Ejecutar `fase3_dashboard/sql/066_pipeline_observabilidad_mirror.sql` en Supabase (ALTER TABLE aditivo). Hasta entonces el poller loguea un warning y el panel muestra "Sin actas" — sin romper nada.
+2. Deploy del dashboard (panel nuevo) — solo Gerardo (DEPLOY_RULES).
+3. Validación viva end-to-end: con 066 aplicada + poller corriendo + deploy, una corrida real deja acta y el panel la muestra contra datos vivos.
+
+> Mientras 1-3 no se hagan, el acta y las alertas **ya se escriben localmente** (fuente de verdad); solo el reflejo en la UI espera el deploy.

--- a/fase3_dashboard/mol-dashboard/__tests__/component/fabrica-page.test.tsx
+++ b/fase3_dashboard/mol-dashboard/__tests__/component/fabrica-page.test.tsx
@@ -32,6 +32,23 @@ function setupHandlers() {
     http.post('/api/pipeline-commands', () => {
       return HttpResponse.json({ id: 'cmd-new', estado: 'pendiente' }, { status: 201 })
     }),
+    // SPEC S1C-F0.3 — última corrida + alertas (acta real producida por el pipeline)
+    http.get('/api/pipeline-last-run', () => {
+      return HttpResponse.json({
+        ultimaActa: {
+          acta_id: 'acta_20260616_1432', started_at: '2026-06-16T14:32:00',
+          finished_at: '2026-06-16T14:40:00', invocador: 'poller',
+          alcance_entrada: 100, alcance_procesado: 97, resultado: 'fallida',
+          fallos: [{ severidad: 'error', tipo: 'ollama_down', mensaje: 'NLP aborto: Connection refused' }],
+          matching_run_id: 'run_20260616_1433',
+        },
+        alertas: [
+          { timestamp: '2026-06-16T14:40:00', severidad: 'error', tipo: 'ollama_down',
+            mensaje: 'NLP aborto: Connection refused', acta_id: 'acta_20260616_1432' },
+        ],
+        timestamp: '2026-06-16T14:41:00',
+      })
+    }),
   )
 }
 
@@ -121,6 +138,29 @@ describe('FabricaPage', () => {
         expect(screen.getByText('Actividad reciente')).toBeInTheDocument()
       })
       expect(screen.getAllByText(/Completado/).length).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  // SPEC S1C-F0.3 — el panel renderiza el acta real (no mock interno)
+  describe('última corrida + alertas', () => {
+    it('muestra la sección y el acta con su resultado', async () => {
+      render(<FabricaPage />)
+      await waitFor(() => {
+        expect(screen.getByText('Última corrida')).toBeInTheDocument()
+      })
+      expect(screen.getByText('acta_20260616_1432')).toBeInTheDocument()
+      expect(screen.getByText(/fallida/)).toBeInTheDocument()
+      expect(screen.getByText(/vía poller/)).toBeInTheDocument()
+      expect(screen.getByText(/run_20260616_1433/)).toBeInTheDocument()
+    })
+
+    it('muestra las alertas recientes con su tipo y mensaje', async () => {
+      render(<FabricaPage />)
+      await waitFor(() => {
+        expect(screen.getByText(/Alertas recientes/)).toBeInTheDocument()
+      })
+      expect(screen.getAllByText(/ollama_down/).length).toBeGreaterThanOrEqual(1)
+      expect(screen.getAllByText(/Connection refused/).length).toBeGreaterThanOrEqual(1)
     })
   })
 })

--- a/fase3_dashboard/mol-dashboard/app/admin/procesamiento/fabrica/page.tsx
+++ b/fase3_dashboard/mol-dashboard/app/admin/procesamiento/fabrica/page.tsx
@@ -36,9 +36,32 @@ interface Command {
   duracion_seg: number | null;
 }
 
+// SPEC S1C-F0.3 — observabilidad del Eje 1
+interface Acta {
+  acta_id: string;
+  started_at: string;
+  finished_at: string | null;
+  invocador: string;
+  alcance_entrada: number | null;
+  alcance_procesado: number | null;
+  resultado: "ok" | "fallida" | "incompleta" | null;
+  fallos: { severidad: string; tipo: string; mensaje: string }[] | null;
+  matching_run_id: string | null;
+}
+
+interface Alerta {
+  timestamp: string;
+  severidad: "info" | "warning" | "error" | "critico";
+  tipo: string;
+  mensaje: string;
+  acta_id: string | null;
+}
+
 export default function FabricaPage() {
   const [status, setStatus] = useState<LocalStatus | null>(null);
   const [commands, setCommands] = useState<Command[]>([]);
+  const [lastRun, setLastRun] = useState<Acta | null>(null);
+  const [alertas, setAlertas] = useState<Alerta[]>([]);
   const [loading, setLoading] = useState(true);
   const [executing, setExecuting] = useState<string | null>(null);
   const [message, setMessage] = useState<{ type: "ok" | "error"; text: string } | null>(null);
@@ -47,9 +70,10 @@ export default function FabricaPage() {
 
   const loadData = useCallback(async () => {
     try {
-      const [statusRes, cmdsRes] = await Promise.all([
+      const [statusRes, cmdsRes, lastRunRes] = await Promise.all([
         fetch("/api/pipeline-local-status"),
         fetch("/api/pipeline-commands?limit=10"),
+        fetch("/api/pipeline-last-run"),
       ]);
 
       if (statusRes.ok) {
@@ -59,6 +83,11 @@ export default function FabricaPage() {
       if (cmdsRes.ok) {
         const data = await cmdsRes.json();
         setCommands(data.commands || []);
+      }
+      if (lastRunRes.ok) {
+        const data = await lastRunRes.json();
+        setLastRun(data.ultimaActa || null);
+        setAlertas(data.alertas || []);
       }
     } catch {} finally {
       setLoading(false);
@@ -209,6 +238,65 @@ export default function FabricaPage() {
             Ultimo run: {formatComando(commands[0].comando)} · {commands[0].resultado.procesadas || "?"} procesadas
             {commands[0].resultado.errores ? ` · ${commands[0].resultado.errores} errores (${commands[0].resultado.procesadas ? Math.round(commands[0].resultado.errores / commands[0].resultado.procesadas * 100) : 0}%)` : " · 0 errores"}
             {commands[0].duracion_seg != null && ` · ${formatDuration(commands[0].duracion_seg)}`}
+          </div>
+        )}
+      </div>
+
+      {/* ═══ ÚLTIMA CORRIDA + ALERTAS (SPEC S1C-F0.3) ═══ */}
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-5">
+        <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-4">
+          Última corrida
+        </h2>
+
+        {!lastRun ? (
+          <p className="text-sm text-gray-400 py-2">
+            Sin actas registradas todavía. La próxima corrida del pipeline deja acta.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            <div className="flex items-center gap-3 flex-wrap text-sm">
+              <ActaBadge resultado={lastRun.resultado} />
+              <span className="text-gray-700 font-medium">{lastRun.acta_id}</span>
+              <span className="text-gray-400">·</span>
+              <span className="text-gray-500">vía {lastRun.invocador}</span>
+              <span className="text-gray-400">·</span>
+              <span className="text-gray-500">{formatTime(lastRun.finished_at || lastRun.started_at)}</span>
+            </div>
+            <div className="text-sm text-gray-600">
+              Entraron {(lastRun.alcance_entrada ?? 0).toLocaleString("es-AR")} ·
+              procesadas {(lastRun.alcance_procesado ?? 0).toLocaleString("es-AR")}
+              {lastRun.matching_run_id && <span className="text-gray-400"> · matching {lastRun.matching_run_id}</span>}
+            </div>
+            {lastRun.fallos && lastRun.fallos.length > 0 && (
+              <div className="text-xs text-gray-500 space-y-1 pt-1">
+                {lastRun.fallos.map((f, i) => (
+                  <div key={i} className="flex items-center gap-1.5">
+                    <AlertCircle className="w-3 h-3 text-amber-500 shrink-0" />
+                    <span className="font-mono text-gray-400">{f.tipo}</span>
+                    <span className="text-gray-600 truncate">{f.mensaje}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mt-5 mb-2">
+          Alertas recientes {alertas.length > 0 && <span className="text-gray-300">({alertas.length})</span>}
+        </h3>
+        {alertas.length === 0 ? (
+          <p className="text-sm text-gray-400 py-1">Sin alertas.</p>
+        ) : (
+          <div className="space-y-1.5">
+            {alertas.slice(0, 8).map((a, i) => (
+              <div key={i} className="flex items-start gap-2 text-xs">
+                <AlertaIcon severidad={a.severidad} />
+                <span className="text-gray-400 font-mono shrink-0">{a.severidad}</span>
+                <span className="text-gray-400 font-mono shrink-0">{a.tipo}</span>
+                <span className="text-gray-600">{a.mensaje}</span>
+                <span className="text-gray-300 ml-auto shrink-0">{formatTime(a.timestamp)}</span>
+              </div>
+            ))}
           </div>
         )}
       </div>
@@ -416,4 +504,27 @@ const COMANDO_LABELS: Record<string, string> = {
 
 function formatComando(cmd: string): string {
   return COMANDO_LABELS[cmd] || cmd;
+}
+
+// SPEC S1C-F0.3 — badge de resultado del acta
+function ActaBadge({ resultado }: { resultado: "ok" | "fallida" | "incompleta" | null }) {
+  const map: Record<string, { cls: string; txt: string }> = {
+    ok: { cls: "bg-green-100 text-green-700", txt: "ok" },
+    fallida: { cls: "bg-red-100 text-red-700", txt: "fallida" },
+    incompleta: { cls: "bg-amber-100 text-amber-700", txt: "incompleta" },
+  };
+  const m = resultado ? map[resultado] : { cls: "bg-blue-100 text-blue-700", txt: "en curso" };
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${m.cls}`}>
+      ● {m.txt}
+    </span>
+  );
+}
+
+function AlertaIcon({ severidad }: { severidad: string }) {
+  const color =
+    severidad === "critico" || severidad === "error" ? "text-red-500"
+    : severidad === "warning" ? "text-amber-500"
+    : "text-gray-400";
+  return <AlertCircle className={`w-3 h-3 shrink-0 mt-0.5 ${color}`} />;
 }

--- a/fase3_dashboard/mol-dashboard/app/api/pipeline-last-run/route.ts
+++ b/fase3_dashboard/mol-dashboard/app/api/pipeline-last-run/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin, isAuthError } from '@/lib/api-auth';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+let supabaseAdmin: SupabaseClient | null = null;
+
+function getSupabaseAdmin(): SupabaseClient | null {
+  if (supabaseAdmin) return supabaseAdmin;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  supabaseAdmin = createClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false }
+  });
+  return supabaseAdmin;
+}
+
+// GET: última acta de corrida + alertas recientes (SPEC S1C-F0.3).
+// Lee el espejo que el poller sube a pipeline_local_status (fuente de verdad
+// local: pipeline_run_actas / pipeline_alertas en SQLite).
+export async function GET(request: NextRequest) {
+  const auth = await requireAdmin(request);
+  if (isAuthError(auth)) return auth;
+
+  const client = getSupabaseAdmin();
+  if (!client) return NextResponse.json({ error: 'Supabase no configurado' }, { status: 500 });
+
+  const { data, error } = await client
+    .from('pipeline_local_status')
+    .select('ultima_acta, alertas_recientes, timestamp')
+    .eq('id', 'current')
+    .maybeSingle();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({
+    ultimaActa: data?.ultima_acta ?? null,
+    alertas: data?.alertas_recientes ?? [],
+    timestamp: data?.timestamp ?? null,
+  });
+}

--- a/fase3_dashboard/sql/066_pipeline_observabilidad_mirror.sql
+++ b/fase3_dashboard/sql/066_pipeline_observabilidad_mirror.sql
@@ -1,0 +1,8 @@
+-- Migration 066: Espejo de observabilidad en pipeline_local_status (SPEC S1C-F0.3)
+-- El poller sube la última acta de corrida + alertas recientes (fuente de verdad
+-- local en SQLite: pipeline_run_actas / pipeline_alertas) para que la Fábrica las muestre.
+--
+-- ADITIVA: dos columnas JSONB nuevas sobre la fila única id='current'.
+
+ALTER TABLE pipeline_local_status ADD COLUMN IF NOT EXISTS ultima_acta JSONB;
+ALTER TABLE pipeline_local_status ADD COLUMN IF NOT EXISTS alertas_recientes JSONB;

--- a/scripts/observabilidad.py
+++ b/scripts/observabilidad.py
@@ -23,8 +23,14 @@ from pathlib import Path
 PROJECT_DIR = Path(__file__).resolve().parent.parent
 DB_PATH = PROJECT_DIR / "database" / "bumeran_scraping.db"
 
+# Log estructurado de alertas (fuente local, independiente de la tabla y de Supabase)
+ALERTAS_JSONL = PROJECT_DIR / "logs" / "pipeline_alertas.jsonl"
+
 # Mismo límite que el subprocess timeout del poller (pipeline_command_poller.py)
 RUN_TIMEOUT_SECONDS = 8 * 3600
+
+# Severidades que, registradas en una corrida, la marcan como `fallida`.
+SEVERIDADES_FALLIDA = ("error", "critico")
 
 
 def _conn():
@@ -70,8 +76,8 @@ def barrer_actas_huerfanas(con=None):
           no es confiable: reinicio que reusa PIDs, u otro host).
     Una corrida viva (PID vivo dentro del timeout) NUNCA se marca incompleta.
 
-    Devuelve la lista de acta_id barridas. No emite alertas en este paso (Paso 2);
-    el Paso 3 engancha `emitir_alerta('corrida_incompleta', ...)` por cada barrida.
+    Devuelve la lista de acta_id barridas y emite una alerta `corrida_incompleta`
+    por cada una (tabla + jsonl).
     """
     own = con is None
     if own:
@@ -98,11 +104,62 @@ def barrer_actas_huerfanas(con=None):
                 "WHERE acta_id = ?",
                 (_now(), acta_id),
             )
-            barridas.append(acta_id)
+            barridas.append((acta_id, started_at, pid, host))
     con.commit()
     if own:
         con.close()
-    return barridas
+
+    # Emitir alerta por cada acta barrida (corrida que empezó y nunca cerró).
+    for acta_id, started_at, pid, host in barridas:
+        emitir_alerta(
+            "error", "corrida_incompleta",
+            f"Acta {acta_id} quedó incompleta (corrida muerta sin cierre)",
+            acta_id=acta_id,
+            contexto={"started_at": started_at, "pid": pid, "host": host},
+        )
+    return [b[0] for b in barridas]
+
+
+def emitir_alerta(severidad, tipo, mensaje, acta_id=None, contexto=None):
+    """Registra una alerta del pipeline en la tabla `pipeline_alertas` Y en
+    `logs/pipeline_alertas.jsonl` (doble persistencia local, independiente).
+
+    Nunca lanza: la observabilidad no puede romper el pipeline. Cada destino se
+    escribe en su propio try/except, así un fallo en uno no impide el otro.
+
+    Devuelve el registro emitido (dict).
+    """
+    ts = _now()
+    contexto = contexto or {}
+    registro = {
+        "timestamp": ts, "severidad": severidad, "tipo": tipo,
+        "mensaje": mensaje, "acta_id": acta_id, "contexto": contexto,
+    }
+
+    # 1) Tabla local
+    try:
+        con = _conn()
+        con.execute(
+            "INSERT INTO pipeline_alertas "
+            "(timestamp, severidad, tipo, mensaje, acta_id, contexto) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (ts, severidad, tipo, mensaje, acta_id,
+             json.dumps(contexto, ensure_ascii=False)),
+        )
+        con.commit()
+        con.close()
+    except Exception:
+        pass
+
+    # 2) Log estructurado (una alerta por línea)
+    try:
+        ALERTAS_JSONL.parent.mkdir(parents=True, exist_ok=True)
+        with open(ALERTAS_JSONL, "a", encoding="utf-8") as f:
+            f.write(json.dumps(registro, ensure_ascii=False) + "\n")
+    except Exception:
+        pass
+
+    return registro
 
 
 def crear_acta(invocador="terminal", args="", alcance_entrada=None):

--- a/scripts/observabilidad.py
+++ b/scripts/observabilidad.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Observabilidad del Eje 1 — acta de corrida + alertas (SPEC S1C-F0.3).
+
+Acta de corrida (tabla local pipeline_run_actas): fuente de verdad a nivel-corrida.
+Se crea al inicio del pipeline y se cierra al final con resultado.
+
+Mecanismo de `incompleta` (decisión consciente, ver spec §4.1):
+  Una corrida en curso y una muerta se ven igual con finished_at IS NULL.
+  El barrido `barrer_actas_huerfanas()` (invocado al INICIO de cada corrida,
+  antes de crear la nueva acta) las distingue por PID vivo + host + timeout.
+
+Paso 3 (alertas) agrega `emitir_alerta()` sobre este mismo módulo.
+"""
+
+import os
+import json
+import socket
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+PROJECT_DIR = Path(__file__).resolve().parent.parent
+DB_PATH = PROJECT_DIR / "database" / "bumeran_scraping.db"
+
+# Mismo límite que el subprocess timeout del poller (pipeline_command_poller.py)
+RUN_TIMEOUT_SECONDS = 8 * 3600
+
+
+def _conn():
+    return sqlite3.connect(str(DB_PATH))
+
+
+def _now():
+    return datetime.now().isoformat()
+
+
+def _host():
+    try:
+        return socket.gethostname()
+    except Exception:
+        return "unknown"
+
+
+def _pid_vivo(pid, host):
+    """True si `pid` corresponde a un proceso vivo EN ESTE host.
+
+    El PID solo es comparable dentro del mismo host: si el acta es de otro host
+    no podemos verificar el proceso, así que cae al respaldo por timeout.
+    """
+    if not pid or host != _host():
+        return False
+    try:
+        os.kill(int(pid), 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # existe pero no es nuestro → vivo
+    except (OSError, ValueError, TypeError):
+        return False
+    return True
+
+
+def barrer_actas_huerfanas(con=None):
+    """Marca como `incompleta` las actas abiertas (finished_at IS NULL) que están muertas.
+
+    Regla (ver spec §4.1): un acta abierta es muerta si, en su mismo host,
+      (1) su PID ya no vive, o
+      (2) su started_at supera RUN_TIMEOUT_SECONDS (respaldo cuando el PID
+          no es confiable: reinicio que reusa PIDs, u otro host).
+    Una corrida viva (PID vivo dentro del timeout) NUNCA se marca incompleta.
+
+    Devuelve la lista de acta_id barridas. No emite alertas en este paso (Paso 2);
+    el Paso 3 engancha `emitir_alerta('corrida_incompleta', ...)` por cada barrida.
+    """
+    own = con is None
+    if own:
+        con = _conn()
+    barridas = []
+    ahora = datetime.now()
+    rows = con.execute(
+        "SELECT acta_id, started_at, pid, host FROM pipeline_run_actas "
+        "WHERE finished_at IS NULL"
+    ).fetchall()
+    for acta_id, started_at, pid, host in rows:
+        muerta = not _pid_vivo(pid, host)
+        if not muerta:
+            # PID vivo: respaldo por timeout
+            try:
+                edad = (ahora - datetime.fromisoformat(started_at)).total_seconds()
+                if edad > RUN_TIMEOUT_SECONDS:
+                    muerta = True
+            except (ValueError, TypeError):
+                pass
+        if muerta:
+            con.execute(
+                "UPDATE pipeline_run_actas SET finished_at = ?, resultado = 'incompleta' "
+                "WHERE acta_id = ?",
+                (_now(), acta_id),
+            )
+            barridas.append(acta_id)
+    con.commit()
+    if own:
+        con.close()
+    return barridas
+
+
+def crear_acta(invocador="terminal", args="", alcance_entrada=None):
+    """Crea el acta de la corrida en curso (resultado NULL hasta cerrar)."""
+    acta_id = f"acta_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    con = _conn()
+    con.execute(
+        "INSERT INTO pipeline_run_actas "
+        "(acta_id, started_at, invocador, args, alcance_entrada, pid, host) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (acta_id, _now(), invocador, args, alcance_entrada, os.getpid(), _host()),
+    )
+    con.commit()
+    con.close()
+    return acta_id
+
+
+def cerrar_acta(acta_id, resultado, alcance_procesado=None,
+                matching_run_id=None, fallos=None):
+    """Cierra el acta con resultado ∈ {ok, fallida, incompleta} y la lista de fallos."""
+    if not acta_id:
+        return
+    con = _conn()
+    con.execute(
+        "UPDATE pipeline_run_actas SET finished_at = ?, resultado = ?, "
+        "alcance_procesado = ?, matching_run_id = ?, fallos = ? WHERE acta_id = ?",
+        (_now(), resultado, alcance_procesado, matching_run_id,
+         json.dumps(fallos or [], ensure_ascii=False), acta_id),
+    )
+    con.commit()
+    con.close()
+
+
+def invocador_actual():
+    """Detecta cómo se invocó la corrida: el poller setea MOL_INVOCADOR=poller."""
+    return os.environ.get("MOL_INVOCADOR", "terminal")

--- a/scripts/pipeline_command_poller.py
+++ b/scripts/pipeline_command_poller.py
@@ -256,6 +256,8 @@ def execute_command(client, cmd, dry_run=False):
         env = os.environ.copy()
         if 'OLLAMA_HOST' not in env:
             env['OLLAMA_HOST'] = '172.17.0.1'
+        # SPEC S1C-F0.3: el acta de corrida registra quién la invocó.
+        env['MOL_INVOCADOR'] = 'poller'
 
         result = subprocess.run(
             full_cmd,
@@ -334,6 +336,52 @@ def execute_command(client, cmd, dry_run=False):
         return False
 
 
+def _leer_observabilidad_local(conn):
+    """Lee la última acta y las alertas recientes del SQLite local (SPEC S1C-F0.3).
+
+    Devuelve (ultima_acta: dict|None, alertas_recientes: list). Tolerante a que las
+    tablas no existan (migración 025 no aplicada) → devuelve (None, []).
+    """
+    ultima_acta = None
+    alertas = []
+    try:
+        cur = conn.execute(
+            "SELECT acta_id, started_at, finished_at, invocador, args, "
+            "alcance_entrada, alcance_procesado, resultado, fallos, matching_run_id "
+            "FROM pipeline_run_actas ORDER BY started_at DESC LIMIT 1"
+        )
+        row = cur.fetchone()
+        if row:
+            cols = [d[0] for d in cur.description]
+            ultima_acta = dict(zip(cols, row))
+            if ultima_acta.get("fallos"):
+                try:
+                    ultima_acta["fallos"] = json.loads(ultima_acta["fallos"])
+                except (json.JSONDecodeError, TypeError):
+                    ultima_acta["fallos"] = []
+    except Exception:
+        pass
+
+    try:
+        cur = conn.execute(
+            "SELECT timestamp, severidad, tipo, mensaje, acta_id, contexto "
+            "FROM pipeline_alertas ORDER BY id DESC LIMIT 10"
+        )
+        cols = [d[0] for d in cur.description]
+        for row in cur.fetchall():
+            a = dict(zip(cols, row))
+            if a.get("contexto"):
+                try:
+                    a["contexto"] = json.loads(a["contexto"])
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            alertas.append(a)
+    except Exception:
+        pass
+
+    return ultima_acta, alertas
+
+
 def sync_local_status(client):
     """Sube el estado real de SQLite a Supabase para que la Fábrica lo muestre."""
     db_path = PROJECT_DIR / "database" / "bumeran_scraping.db"
@@ -373,6 +421,9 @@ def sync_local_status(client):
         except Exception:
             errores = 0
 
+        # Observabilidad (SPEC S1C-F0.3): leer acta + alertas con la misma conexión.
+        ultima_acta, alertas_recientes = _leer_observabilidad_local(conn)
+
         conn.close()
 
         # Sync log + count real from Supabase
@@ -409,6 +460,17 @@ def sync_local_status(client):
             'pendientes_sync': max(validadas - en_supabase, 0),
             'ultimo_sync': ultimo_sync,
         }).execute()
+
+        # Espejo de observabilidad en columnas JSONB aparte. Separado del upsert
+        # principal para que, si la migración 066 (columnas) aún no se aplicó en
+        # Supabase, el fallo no rompa el sync de estado.
+        try:
+            client.table('pipeline_local_status').update({
+                'ultima_acta': ultima_acta,
+                'alertas_recientes': alertas_recientes,
+            }).eq('id', 'current').execute()
+        except Exception as e:
+            print(f"[POLLER] WARN: no se pudo espejar observabilidad (¿migración 066?): {e}")
 
     except Exception as e:
         print(f"[POLLER] WARN: No se pudo sync status local: {e}")

--- a/scripts/run_validated_pipeline.py
+++ b/scripts/run_validated_pipeline.py
@@ -73,6 +73,7 @@ from database.nlp_validator import NLPValidator
 from scripts.sync_learnings import sync_learnings_yaml
 from scripts.observabilidad import (
     barrer_actas_huerfanas, crear_acta, cerrar_acta, invocador_actual,
+    emitir_alerta,
 )
 
 DB_PATH = Path(__file__).parent.parent / "database" / "bumeran_scraping.db"
@@ -272,6 +273,15 @@ def run_full_pipeline(
         # Observabilidad nunca debe romper el pipeline.
         safe_print(f"[ACTA] Warning: no se pudo abrir acta: {e}")
 
+    def _registrar_fallo(severidad, tipo, mensaje, contexto=None):
+        """Acumula el fallo para el resultado del acta y emite la alerta (tabla+jsonl).
+        Envuelto: el registro de alertas tampoco puede romper el pipeline."""
+        acta_fallos.append({"severidad": severidad, "tipo": tipo, "mensaje": mensaje})
+        try:
+            emitir_alerta(severidad, tipo, mensaje, acta_id=acta_id, contexto=contexto)
+        except Exception:
+            pass
+
     # === LOOP PRINCIPAL ===
     while True:
         nlp_iteration += 1
@@ -326,11 +336,11 @@ def run_full_pipeline(
                         "connection", "conexion", "refused", "rechaz",
                         "11434", "ollama", "timed out", "max retries",
                     ))
-                    acta_fallos.append({
-                        "severidad": "error",
-                        "tipo": "ollama_down" if _es_ollama else "nlp_fallo",
-                        "mensaje": f"NLP aborto: {e}",
-                    })
+                    _registrar_fallo(
+                        "error", "ollama_down" if _es_ollama else "nlp_fallo",
+                        f"NLP aborto: {e}",
+                        contexto={"ids_count": len(nlp_ids)},
+                    )
             else:
                 if verbose:
                     safe_print("No hay ofertas pendientes de NLP")
@@ -687,10 +697,7 @@ def run_full_pipeline(
     except Exception as e:
         safe_print(f"Warning: Error exportando Excel: {e}")
         resultados["excel_export"] = f"Error: {e}"
-        acta_fallos.append({
-            "severidad": "warning", "tipo": "export_fallo",
-            "mensaje": f"Export Excel fallo: {e}",
-        })
+        _registrar_fallo("warning", "export_fallo", f"Export Excel fallo: {e}")
 
     # PASO 8: Sincronizar learnings.yaml
     if verbose:
@@ -704,10 +711,7 @@ def run_full_pipeline(
     except Exception as e:
         safe_print(f"Warning: Error sincronizando learnings.yaml: {e}")
         resultados["learnings_sync"] = False
-        acta_fallos.append({
-            "severidad": "warning", "tipo": "sync_no_corrio",
-            "mensaje": f"Sync learnings.yaml fallo: {e}",
-        })
+        _registrar_fallo("warning", "sync_no_corrio", f"Sync learnings.yaml fallo: {e}")
 
     # === CIERRE DEL ACTA (SPEC S1C-F0.3) ===
     # resultado: 'fallida' si hubo algun fallo error/critico (NLP/Ollama); 'ok' si no.
@@ -783,6 +787,16 @@ def main():
             safe_print(f"\nOpciones:")
             safe_print(f"  1. Resolver errores: --ids {','.join(block_info['ids'])}")
             safe_print(f"  2. Forzar nuevo lote: --force-new-batch")
+            # Paso bloqueante: no se crea acta (la corrida no arranca). Alerta sin acta_id.
+            try:
+                emitir_alerta(
+                    "warning", "paso_bloqueante",
+                    f"Lote {block_info['lote']} bloqueado: {block_info['errores']} errores sin resolver",
+                    contexto={"lote": block_info['lote'], "errores": block_info['errores'],
+                              "ids": block_info['ids'][:20]},
+                )
+            except Exception:
+                pass
             conn.close()
             sys.exit(1)
 

--- a/scripts/run_validated_pipeline.py
+++ b/scripts/run_validated_pipeline.py
@@ -71,6 +71,9 @@ from database.auto_validator import AutoValidator, validar_ofertas_desde_bd
 from database.auto_corrector import AutoCorrector
 from database.nlp_validator import NLPValidator
 from scripts.sync_learnings import sync_learnings_yaml
+from scripts.observabilidad import (
+    barrer_actas_huerfanas, crear_acta, cerrar_acta, invocador_actual,
+)
 
 DB_PATH = Path(__file__).parent.parent / "database" / "bumeran_scraping.db"
 CONFIG_DIR = Path(__file__).parent.parent / "config"
@@ -246,6 +249,29 @@ def run_full_pipeline(
     nlp_iteration = 0
     ids_to_process = ids
 
+    # === ACTA DE CORRIDA (SPEC S1C-F0.3, observabilidad Eje 1) ===
+    # Barrido primero: marca incompleta cualquier acta huerfana de una corrida muerta.
+    # Recien despues se crea la nueva acta, asi el barrido nunca la toca.
+    acta_fallos = []
+    acta_id = None
+    try:
+        barrer_actas_huerfanas()
+        _acta_args = json.dumps({
+            "limit": limit, "ids": (len(ids) if ids else None),
+            "only_pending": only_pending,
+            "skip_nlp": skip_nlp, "skip_matching": skip_matching,
+        }, ensure_ascii=False)
+        _alcance_entrada = len(ids) if ids else limit
+        acta_id = crear_acta(
+            invocador=invocador_actual(), args=_acta_args,
+            alcance_entrada=_alcance_entrada,
+        )
+        if verbose:
+            safe_print(f"[ACTA] Corrida abierta: {acta_id}")
+    except Exception as e:
+        # Observabilidad nunca debe romper el pipeline.
+        safe_print(f"[ACTA] Warning: no se pudo abrir acta: {e}")
+
     # === LOOP PRINCIPAL ===
     while True:
         nlp_iteration += 1
@@ -295,6 +321,16 @@ def run_full_pipeline(
                 except Exception as e:
                     safe_print(f"Error en NLP: {e}")
                     # Continuar con matching si NLP falla
+                    _msg = str(e).lower()
+                    _es_ollama = any(k in _msg for k in (
+                        "connection", "conexion", "refused", "rechaz",
+                        "11434", "ollama", "timed out", "max retries",
+                    ))
+                    acta_fallos.append({
+                        "severidad": "error",
+                        "tipo": "ollama_down" if _es_ollama else "nlp_fallo",
+                        "mensaje": f"NLP aborto: {e}",
+                    })
             else:
                 if verbose:
                     safe_print("No hay ofertas pendientes de NLP")
@@ -651,6 +687,10 @@ def run_full_pipeline(
     except Exception as e:
         safe_print(f"Warning: Error exportando Excel: {e}")
         resultados["excel_export"] = f"Error: {e}"
+        acta_fallos.append({
+            "severidad": "warning", "tipo": "export_fallo",
+            "mensaje": f"Export Excel fallo: {e}",
+        })
 
     # PASO 8: Sincronizar learnings.yaml
     if verbose:
@@ -664,6 +704,32 @@ def run_full_pipeline(
     except Exception as e:
         safe_print(f"Warning: Error sincronizando learnings.yaml: {e}")
         resultados["learnings_sync"] = False
+        acta_fallos.append({
+            "severidad": "warning", "tipo": "sync_no_corrio",
+            "mensaje": f"Sync learnings.yaml fallo: {e}",
+        })
+
+    # === CIERRE DEL ACTA (SPEC S1C-F0.3) ===
+    # resultado: 'fallida' si hubo algun fallo error/critico (NLP/Ollama); 'ok' si no.
+    # 'incompleta' lo asigna solo el barrido (una corrida muerta nunca llega aca).
+    if acta_id:
+        try:
+            _hubo_error = any(
+                f.get("severidad") in ("error", "critico") for f in acta_fallos
+            )
+            _resultado = "fallida" if _hubo_error else "ok"
+            _matching_run_id = (resultados.get("matching") or {}).get("run_id")
+            _alcance_proc = (resultados.get("matching") or {}).get("total")
+            cerrar_acta(
+                acta_id, resultado=_resultado,
+                alcance_procesado=_alcance_proc,
+                matching_run_id=_matching_run_id,
+                fallos=acta_fallos,
+            )
+            if verbose:
+                safe_print(f"[ACTA] Corrida cerrada: {acta_id} -> {_resultado}")
+        except Exception as e:
+            safe_print(f"[ACTA] Warning: no se pudo cerrar acta: {e}")
 
     return resultados
 

--- a/tests/test_observabilidad_actas.py
+++ b/tests/test_observabilidad_actas.py
@@ -245,6 +245,45 @@ def test_run_pipeline_fallida_emite_alerta_ollama_en_ambos(db_tmp, monkeypatch):
     assert _aparece_en_ambos(db_tmp, "ollama_down")
 
 
+def test_poller_lee_acta_y_alertas_para_espejo(db_tmp):
+    """El lector del poller arma el espejo (última acta + alertas) desde el SQLite local."""
+    import scripts.pipeline_command_poller as poller
+
+    acta_id = obs.crear_acta(invocador="poller", args='{"limit": 3}', alcance_entrada=3)
+    obs.cerrar_acta(acta_id, resultado="fallida", alcance_procesado=2,
+                    fallos=[{"severidad": "error", "tipo": "ollama_down", "mensaje": "x"}])
+    obs.emitir_alerta("error", "ollama_down", "Conexión rechazada", acta_id=acta_id,
+                      contexto={"ids_count": 3})
+
+    con = sqlite3.connect(str(db_tmp))
+    ultima_acta, alertas = poller._leer_observabilidad_local(con)
+    con.close()
+
+    assert ultima_acta["acta_id"] == acta_id
+    assert ultima_acta["resultado"] == "fallida"
+    assert ultima_acta["invocador"] == "poller"
+    # fallos llega deserializado (lista), listo para subir como JSONB
+    assert isinstance(ultima_acta["fallos"], list)
+    assert ultima_acta["fallos"][0]["tipo"] == "ollama_down"
+    assert any(a["tipo"] == "ollama_down" for a in alertas)
+    assert isinstance(alertas[0]["contexto"], dict)
+
+
+def test_poller_lee_observabilidad_sin_tablas_no_rompe(tmp_path):
+    """Si las tablas de observabilidad no existen (migración 025 no aplicada), devuelve (None, [])."""
+    import scripts.pipeline_command_poller as poller
+
+    db = tmp_path / "vacia.db"
+    con = sqlite3.connect(str(db))
+    con.execute("CREATE TABLE ofertas (id INTEGER)")  # BD sin tablas de observabilidad
+    con.commit()
+    ultima_acta, alertas = poller._leer_observabilidad_local(con)
+    con.close()
+
+    assert ultima_acta is None
+    assert alertas == []
+
+
 def test_emitir_alerta_nunca_rompe(monkeypatch, tmp_path):
     """Aunque tabla y jsonl fallen, emitir_alerta no lanza (no rompe el pipeline)."""
     monkeypatch.setattr(obs, "DB_PATH", tmp_path / "no_existe" / "x.db")  # _conn falla

--- a/tests/test_observabilidad_actas.py
+++ b/tests/test_observabilidad_actas.py
@@ -45,13 +45,15 @@ def _restore_streams():
 
 @pytest.fixture
 def db_tmp(tmp_path, monkeypatch):
-    """BD temporal con solo las tablas de observabilidad; redirige el helper a ella."""
+    """BD temporal con solo las tablas de observabilidad; redirige el helper a ella
+    y el jsonl de alertas a tmp (para no contaminar logs/ reales)."""
     db = tmp_path / "obs_test.db"
     con = sqlite3.connect(str(db))
     con.executescript(MIGRATION.read_text())
     con.commit()
     con.close()
     monkeypatch.setattr(obs, "DB_PATH", db)
+    monkeypatch.setattr(obs, "ALERTAS_JSONL", tmp_path / "pipeline_alertas.jsonl")
     return db
 
 
@@ -61,6 +63,22 @@ def _actas(db):
     rows = [dict(r) for r in con.execute("SELECT * FROM pipeline_run_actas")]
     con.close()
     return rows
+
+
+def _alertas_tabla(db):
+    con = sqlite3.connect(str(db))
+    con.row_factory = sqlite3.Row
+    rows = [dict(r) for r in con.execute("SELECT * FROM pipeline_alertas")]
+    con.close()
+    return rows
+
+
+def _alertas_jsonl():
+    import json
+    p = obs.ALERTAS_JSONL
+    if not p.exists():
+        return []
+    return [json.loads(line) for line in p.read_text(encoding="utf-8").splitlines() if line.strip()]
 
 
 # ── Unidad: ciclo de vida del acta ───────────────────────────────────────────
@@ -176,3 +194,67 @@ def test_run_full_pipeline_acta_fallida_por_ollama(db_tmp, monkeypatch):
     assert acta["resultado"] == "fallida"
     fallos = json.loads(acta["fallos"])
     assert any(f["tipo"] == "ollama_down" for f in fallos)
+
+
+# ── Paso 3: alertas en tabla Y jsonl (criterio binario por tipo de fallo) ─────
+
+def _aparece_en_ambos(db, tipo):
+    en_tabla = any(a["tipo"] == tipo for a in _alertas_tabla(db))
+    en_jsonl = any(a["tipo"] == tipo for a in _alertas_jsonl())
+    return en_tabla and en_jsonl
+
+
+def test_emitir_alerta_persiste_en_tabla_y_jsonl(db_tmp):
+    obs.emitir_alerta("error", "ollama_down", "Conexión rechazada 172.17.0.1:11434",
+                      acta_id="acta_x", contexto={"ids_count": 5})
+    # Tabla
+    fila = _alertas_tabla(db_tmp)[0]
+    assert fila["tipo"] == "ollama_down"
+    assert fila["severidad"] == "error"
+    assert fila["acta_id"] == "acta_x"
+    assert '"ids_count": 5' in fila["contexto"]
+    # JSONL
+    linea = _alertas_jsonl()[0]
+    assert linea["tipo"] == "ollama_down"
+    assert linea["contexto"]["ids_count"] == 5
+
+
+def test_barrido_emite_alerta_corrida_incompleta(db_tmp):
+    con = sqlite3.connect(str(db_tmp))
+    con.execute(
+        "INSERT INTO pipeline_run_actas (acta_id, started_at, pid, host) VALUES (?,?,?,?)",
+        ("acta_zombie", "2026-06-16T09:00:00", 999999, obs._host()),
+    )
+    con.commit()
+    con.close()
+
+    obs.barrer_actas_huerfanas()
+
+    assert _aparece_en_ambos(db_tmp, "corrida_incompleta")
+    alerta = [a for a in _alertas_tabla(db_tmp) if a["tipo"] == "corrida_incompleta"][0]
+    assert alerta["acta_id"] == "acta_zombie"
+    assert alerta["severidad"] == "error"
+
+
+def test_run_pipeline_fallida_emite_alerta_ollama_en_ambos(db_tmp, monkeypatch):
+    _patch_pipeline_pesado(monkeypatch, nlp_raise=True)
+
+    rvp.run_full_pipeline(ids=None, limit=1, skip_nlp=False, skip_matching=True,
+                          only_pending=False, verbose=False)
+
+    assert _aparece_en_ambos(db_tmp, "ollama_down")
+
+
+def test_emitir_alerta_nunca_rompe(monkeypatch, tmp_path):
+    """Aunque tabla y jsonl fallen, emitir_alerta no lanza (no rompe el pipeline)."""
+    monkeypatch.setattr(obs, "DB_PATH", tmp_path / "no_existe" / "x.db")  # _conn falla
+    monkeypatch.setattr(obs, "ALERTAS_JSONL", tmp_path / "ro" / "a.jsonl")
+    # crear dir read-only para forzar fallo de escritura del jsonl
+    ro = tmp_path / "ro"
+    ro.mkdir()
+    os.chmod(ro, 0o500)
+    try:
+        reg = obs.emitir_alerta("error", "nlp_fallo", "x")  # no debe lanzar
+        assert reg["tipo"] == "nlp_fallo"
+    finally:
+        os.chmod(ro, 0o700)

--- a/tests/test_observabilidad_actas.py
+++ b/tests/test_observabilidad_actas.py
@@ -1,0 +1,178 @@
+"""
+Tests del acta de corrida — SPEC S1C-F0.3 (Paso 2).
+
+Verifican el punto de control: el acta se escribe correcta en una corrida real
+(inicio/fin/alcance/resultado) y el barrido distingue corrida en curso de muerta.
+
+No requiere Ollama ni toca la BD de producción: usa una BD temporal y mockea
+los pasos pesados del pipeline (NLP, matching, validación, export, sync).
+"""
+
+import os
+import sys
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import scripts.observabilidad as obs
+
+# run_validated_pipeline y export_validation_excel reenvuelven sys.stdout en un
+# TextIOWrapper al importarse (fix de encoding para subprocess Windows). Ese rewrap,
+# si toca el stream de captura de pytest, lo cierra y rompe la sesión. Importamos
+# ambos con stdout redirigido a devnull para que el rewrap envuelva devnull (no la
+# captura de pytest), y restauramos después.
+_orig_stdout, _orig_stderr = sys.stdout, sys.stderr
+_devnull = open(os.devnull, "w")
+sys.stdout = sys.stderr = _devnull
+try:
+    import scripts.run_validated_pipeline as rvp  # noqa: E402
+    import scripts.exports.export_validation_excel  # noqa: E402,F401
+finally:
+    sys.stdout, sys.stderr = _orig_stdout, _orig_stderr
+
+MIGRATION = Path(__file__).resolve().parent.parent / "database" / "migrations" / "025_pipeline_observabilidad.sql"
+
+
+@pytest.fixture(autouse=True)
+def _restore_streams():
+    """Varios módulos del pipeline reenvuelven sys.stdout al importarse; restauramos
+    los streams de pytest tras cada test para no romper su captura en el teardown."""
+    so, se = sys.stdout, sys.stderr
+    yield
+    sys.stdout, sys.stderr = so, se
+
+
+@pytest.fixture
+def db_tmp(tmp_path, monkeypatch):
+    """BD temporal con solo las tablas de observabilidad; redirige el helper a ella."""
+    db = tmp_path / "obs_test.db"
+    con = sqlite3.connect(str(db))
+    con.executescript(MIGRATION.read_text())
+    con.commit()
+    con.close()
+    monkeypatch.setattr(obs, "DB_PATH", db)
+    return db
+
+
+def _actas(db):
+    con = sqlite3.connect(str(db))
+    con.row_factory = sqlite3.Row
+    rows = [dict(r) for r in con.execute("SELECT * FROM pipeline_run_actas")]
+    con.close()
+    return rows
+
+
+# ── Unidad: ciclo de vida del acta ───────────────────────────────────────────
+
+def test_crear_y_cerrar_acta_ok(db_tmp):
+    acta_id = obs.crear_acta(invocador="terminal", args='{"limit": 5}', alcance_entrada=5)
+    abierta = _actas(db_tmp)[0]
+    assert abierta["finished_at"] is None
+    assert abierta["resultado"] is None       # en curso
+    assert abierta["alcance_entrada"] == 5
+    assert abierta["pid"] == os.getpid()
+
+    obs.cerrar_acta(acta_id, resultado="ok", alcance_procesado=4, matching_run_id="run_x")
+    cerrada = _actas(db_tmp)[0]
+    assert cerrada["finished_at"] is not None
+    assert cerrada["resultado"] == "ok"
+    assert cerrada["alcance_procesado"] == 4
+    assert cerrada["matching_run_id"] == "run_x"
+
+
+# ── Unidad: barrido distingue en curso vs muerta (mecanismo de `incompleta`) ──
+
+def test_barrido_marca_muerta_y_respeta_viva(db_tmp):
+    con = sqlite3.connect(str(db_tmp))
+    host = obs._host()
+    # Acta MUERTA: pid inexistente, mismo host
+    con.execute(
+        "INSERT INTO pipeline_run_actas (acta_id, started_at, pid, host) VALUES (?,?,?,?)",
+        ("acta_muerta", "2026-06-16T10:00:00", 999999, host),
+    )
+    # Acta EN CURSO: pid de este proceso (vivo), started_at reciente, mismo host
+    con.execute(
+        "INSERT INTO pipeline_run_actas (acta_id, started_at, pid, host) VALUES (?,?,?,?)",
+        ("acta_viva", obs._now(), os.getpid(), host),
+    )
+    con.commit()
+    con.close()
+
+    barridas = obs.barrer_actas_huerfanas()
+
+    assert barridas == ["acta_muerta"]
+    estados = {a["acta_id"]: a for a in _actas(db_tmp)}
+    assert estados["acta_muerta"]["resultado"] == "incompleta"
+    assert estados["acta_muerta"]["finished_at"] is not None
+    assert estados["acta_viva"]["resultado"] is None        # viva → se respeta
+    assert estados["acta_viva"]["finished_at"] is None
+
+
+def test_barrido_timeout_respaldo(db_tmp):
+    """Pid vivo pero corrida más vieja que el timeout → incompleta (respaldo)."""
+    con = sqlite3.connect(str(db_tmp))
+    con.execute(
+        "INSERT INTO pipeline_run_actas (acta_id, started_at, pid, host) VALUES (?,?,?,?)",
+        ("acta_vieja", "2020-01-01T00:00:00", os.getpid(), obs._host()),
+    )
+    con.commit()
+    con.close()
+
+    assert obs.barrer_actas_huerfanas() == ["acta_vieja"]
+    assert _actas(db_tmp)[0]["resultado"] == "incompleta"
+
+
+# ── Integración: run_full_pipeline REAL escribe el acta (T1) ──────────────────
+
+class _FakeNLPValidator:
+    def __init__(self, *a, **k):
+        pass
+
+    def validar_desde_bd(self, *a, **k):
+        return {"total": 0, "gate_pass_count": 0, "gate_block_count": 0}
+
+
+def _patch_pipeline_pesado(monkeypatch, nlp_raise=False):
+    """Mockea los colaboradores pesados; deja intacta la lógica de acta."""
+    monkeypatch.setattr(rvp, "NLPValidator", _FakeNLPValidator)
+    monkeypatch.setattr(rvp, "validar_ofertas_desde_bd",
+                        lambda *a, **k: {"total": 0, "sin_errores": 0, "con_errores": 0})
+    monkeypatch.setattr(rvp, "sync_learnings_yaml", lambda *a, **k: None)
+    monkeypatch.setattr("scripts.exports.export_validation_excel.export_validation",
+                        lambda *a, **k: "/tmp/fake.xlsx")
+    if nlp_raise:
+        monkeypatch.setattr(rvp, "get_ids_without_nlp", lambda *a, **k: ["1"])
+
+        def _boom(*a, **k):
+            raise ConnectionError("Connection refused: 172.17.0.1:11434")
+
+        monkeypatch.setattr(rvp, "run_nlp_for_ids", _boom)
+
+
+def test_run_full_pipeline_escribe_acta_ok(db_tmp, monkeypatch):
+    _patch_pipeline_pesado(monkeypatch)
+
+    rvp.run_full_pipeline(ids=["1", "2"], skip_nlp=True, skip_matching=True, verbose=False)
+
+    actas = _actas(db_tmp)
+    assert len(actas) == 1
+    acta = actas[0]
+    assert acta["started_at"] is not None
+    assert acta["finished_at"] is not None
+    assert acta["resultado"] == "ok"
+    assert acta["alcance_entrada"] == 2
+    assert acta["invocador"] == "terminal"
+
+
+def test_run_full_pipeline_acta_fallida_por_ollama(db_tmp, monkeypatch):
+    _patch_pipeline_pesado(monkeypatch, nlp_raise=True)
+
+    rvp.run_full_pipeline(ids=None, limit=1, skip_nlp=False, skip_matching=True,
+                          only_pending=False, verbose=False)
+
+    import json
+    acta = _actas(db_tmp)[0]
+    assert acta["resultado"] == "fallida"
+    fallos = json.loads(acta["fallos"])
+    assert any(f["tipo"] == "ollama_down" for f in fallos)


### PR DESCRIPTION
# feat(spec-s1c-f03): Observabilidad del Eje 1 — acta de corrida + alertas (log + UI)

Tercer spec de la Fase 0 del master S1.C, y **el primero que toca código de producción**. Cierra el agujero negro de observabilidad del Eje 1: cada corrida del pipeline deja acta, cada fallo deja alerta estructurada, y un panel en la pantalla de fábrica lo muestra sin abrir terminal.

Riesgo contenido por diseño: **agrega registro y visualización, no cambia la lógica de qué se procesa**. Toda la observabilidad está envuelta en try/except — nunca puede romper el pipeline.

## Qué resuelve

Antes: si la corrida moría en NLP (Ollama caído) **no dejaba ninguna fila local** — el fallo más importante era invisible. `pipeline_runs` es matching-scoped (nace tarde, sin `resultado`/`fin`/`fallos`). El registro por-comando del poller vive solo en Supabase y solo para corridas vía poller.

Ahora: acta **local a nivel-corrida** (fuente de verdad, independiente de Supabase y del camino de invocación) + alertas en tabla y log + panel.

## Diseño (verificado contra el código antes de implementar)

- **Acta** (`pipeline_run_actas`, sqlite): se abre al inicio de `run_full_pipeline`, se cierra al fin con `resultado ∈ {ok, fallida, incompleta}`. No toca `pipeline_runs`.
- **Mecanismo de `incompleta`** (decisión consciente): una corrida en curso y una muerta se ven igual con `finished_at IS NULL`. El **barrido al inicio de cada corrida** las distingue por **PID vivo + host + timeout 8 h**. Sesgo elegido: nunca marca incompleta a una corrida viva.
- **Alertas** (`pipeline_alertas` + `logs/pipeline_alertas.jsonl`, doble persistencia local): emitidas en 5 puntos — `nlp_fallo`/`ollama_down`, `export_fallo`, `sync_no_corrio`, `paso_bloqueante`, `corrida_incompleta`.
- **Panel**: sección "Última corrida + Alertas" sumada a `procesamiento/fabrica` (reusa card/toast/polling). Endpoint `/api/pipeline-last-run`. El dato sube local→Supabase piggyback en `sync_local_status` del poller (residencia local = fuente de verdad, UI = espejo).

## Pasos (1 commit c/u)

| Paso | Commit |
|---|---|
| 1 — Migración 025 (acta + alertas, sqlite) | `692c6f35` |
| 2 — Acta en run_validated_pipeline | `3863d6fa` |
| 3 — emitir_alerta en 5 puntos de fallo | `3eee50aa` |
| 4+5 — Migración 066 + poller + endpoint + panel | `e4bf4d1f` |

## Tests

- **Python** (`tests/test_observabilidad_actas.py`): 11 verdes. T1 (run real escribe acta ok/fallida), T2 (barrido viva/muerta/timeout), T3 (alerta en tabla **y** jsonl por tipo), lector del poller, observabilidad nunca rompe el pipeline.
- **Frontend** (`__tests__/component/fabrica-page.test.tsx`): 12 verdes (panel renderiza acta real + alertas). T4.
- Regresión OK: `fabrica-components` (22) + `procesamiento-dashboard` (7).

## Manual pendiente (Gerardo)

1. Ejecutar `fase3_dashboard/sql/066_pipeline_observabilidad_mirror.sql` en Supabase (ALTER aditivo). Hasta entonces el poller loguea warning y el panel muestra "Sin actas" — sin romper nada.
2. Deploy del dashboard (DEPLOY_RULES — solo Gerardo).
3. Validación viva end-to-end.

> El acta y las alertas **ya se escriben localmente** desde el merge; solo el reflejo en UI espera el deploy.

## No incluye

El criterio único de elegibilidad (4 mecanismos + 8 estados) — es F0.4, de alto riesgo, separado a propósito.

## DEPLOY_RULES

No mergear (el merge es de Gerardo). No deploy. Migración Supabase la ejecuta Gerardo.
